### PR TITLE
History graph: empty-window flat line + long-window live throttle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,7 +241,11 @@ requesting client only (`send_to`), never a broadcast, and `TESLA_HISTORY` echoe
 a stale reply can be discarded. History values are returned **raw** (no downsampling); the frontend
 renders them as a **step line** (`StepLeft`) so a value held between records still displays as held.
 (`read_tesla_data_property` keeps an optional `aggregate_window` for capping very large ranges,
-currently unused.)
+currently unused.) When a window logged **nothing** (the value stayed constant, so no record falls
+inside it), the backend **boundary-fills**: it queries the last value before the window start and
+returns two synthetic points (window-start + window-end at that held value) so the graph draws a
+flat held line across the whole range instead of "no data". Only a genuinely absent prior value
+(or an InfluxDB outage, where the boundary query also yields nothing) replies `status=0`.
 
 **Tesla stream value types**: `0` float `double(8B)`; `1` string `length(2B)+UTF-8`;
 `2` bool `uint8(1B)`; `3` dict — sequence of `double(8B)` (Location = lat, lon).
@@ -327,7 +331,8 @@ a dumb byte pipe — it never imports protocol constants or calls concrete servi
   is pushed to the car via `update_temperature` only when climate is next toggled, by design).
   `stream_everything` snapshots all properties to a new client. History: `get_graphable_properties`
   lists the logged numeric (value_float) properties for the History view's dropdown; `get_data_history`
-  reads one property's downsampled history — both are served by request/response handlers that reply
+  reads one property's history and `get_value_before` reads the held value just before a window (the
+  empty-window boundary-fill) — all served by request/response handlers that reply
   to the requesting client only. **Talks to:** `InfluxDBHandler`
   (write/read), `Server` (broadcast/send_to), Teslemetry REST (aiohttp).
 - **`vehicle_data_property.py`**: `VehicleDataProperty` stores one field's value/timestamp,
@@ -382,7 +387,9 @@ with a valid air-temperature reading (avoiding the all-NaN padding slots fmiopen
 snapshot), `read_first_value_day`/`_month` (calculated-field baselines), `read_tesla_data_property`
 (history — the History path serves it **raw**; an optional `aggregate_window` arg can add
 `aggregateWindow(fn: mean) + fill(usePrevious)` to downsample + forward-fill onto a regular grid,
-dropping the leading null windows, but is currently unused). Read failures degrade to `None` rather
+dropping the leading null windows, but is currently unused), and `read_last_value_before` (a
+`last()` query bounded by `stop` — the held value before an empty window, used to boundary-fill the
+History graph with a flat line). Read failures degrade to `None` rather
 than crashing the app. **Talks to:** InfluxDB,
 `Vehicle`. *Flux queries interpolate `data_property_id` via f-strings gated by the `_SAFE_ID` regex
 `^[A-Za-z0-9_\-]+$`, and `aggregate_window` by `_SAFE_WINDOW` (`^[1-9][0-9]*[smhd]$`) — keep both

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -574,9 +574,12 @@ a new/renamed service or widget, a protocol change, a build-command change, or a
 invariant. Treat the doc as part of the change, not an afterthought, and bump §7.7.
 
 ### 7.7 Documentation currency
-This guide and `README.md` are current as of commit **`827824d`** ("Add: History-graph backend —
-graph-properties + history request/response API"), which lands the interactive **History-graph view**:
-the `0x70`–`0x73` request/response protocol, the `(payload, writer)` handler signature, history
-**range code 4 = 1 week**, and the Qt 6.11 build. A frontend-only live-graph mode also rides on these
-codes — out of scope here; see the `frontend_v2` memory.
+This guide and `README.md` are current as of commit **`1184b60`** ("Add: throttle the live History
+tick on long windows"), which — together with the preceding **`cc11bb8`** ("Fix: boundary-fill empty
+History windows with a flat held line") — adds the History-graph **empty-window boundary-fill**
+(`read_last_value_before` / `get_value_before`; a constant-value window now draws a flat line instead
+of "Ei dataa"). The earlier interactive **History-graph view** (commit `827824d`) lands the
+`0x70`–`0x73` request/response protocol, the `(payload, writer)` handler signature, history **range
+code 4 = 1 week**, and the Qt 6.11 build. The frontend-only live-graph mode (and its per-window tick
+throttle) rides on these codes — out of scope here; see the `frontend_v2` memory.
 When you land changes that touch behaviour documented here, update this line to the new HEAD commit.

--- a/backend/src/influxdb_service/influxdb_handler.py
+++ b/backend/src/influxdb_service/influxdb_handler.py
@@ -114,6 +114,64 @@ class InfluxDBHandler:
 
         return len(values), timestamps, values
 
+    async def read_last_value_before(
+        self, data_property_id: str, stop_time: str
+    ) -> float | None:
+        '''
+        Reads the most recent stored value of a property strictly before a given
+        time — used by the History path to draw a flat held line for a window in
+        which nothing was logged (a value that stayed constant). Scans from the
+        start of history up to stop_time and takes the last record, so a value held
+        constant for days is still found.
+        Arguments:
+            data_property_id (str): The property id (InfluxDB "id" tag). Validated
+                against _SAFE_ID before interpolation.
+            stop_time (str): Flux range stop (RFC3339 or relative). Interpolated
+                into the query, so it must be code-generated (never client input),
+                exactly like time_start/time_end in read_tesla_data_property.
+        Returns:
+            float | None: The held value before stop_time, or None if InfluxDB is
+                unreachable / the query fails / the property was never logged before.
+        '''
+        if not _SAFE_ID.match(data_property_id):
+            raise ValueError(f"Invalid data_property_id: {data_property_id!r}")
+
+        query = f'from(bucket:"{self.__bucket}")'
+        query += f"\n  |> range(start: 0, stop: {stop_time})"
+        query += '\n  |> filter(fn: (r) => r["_measurement"] == "tesla_data")'
+        query += f'\n  |> filter(fn: (r) => r["id"] == "{data_property_id}")'
+        query += '\n  |> filter(fn: (r) => r["_field"] == "value_float")'
+        query += '\n  |> keep(columns: ["_time", "_value"])'
+        query += '\n  |> last()'
+
+        try:
+            result = await self.__client.query_api().query(query=query)
+        except Exception as e:
+            # InfluxDB unreachable or query failure must degrade to "no prior value"
+            # so an empty-window history read simply stays empty ("Ei dataa") rather
+            # than fabricating a line — and never propagates to the caller.
+            logger.warning(
+                "InfluxDB last-value-before read failed for %s: %s: %s",
+                data_property_id, type(e).__name__, e,
+            )
+            return None
+
+        if len(result) > 1:
+            raise Exception("There was more than one table")
+
+        if len(result) == 0:
+            return None
+
+        table = result[0]
+        if not table.records:
+            return None
+
+        value = table.records[0].get_value()
+        if value is None:
+            return None
+        logger.debug("Last value before %s for %s: %s", stop_time, data_property_id, value)
+        return float(value)
+
     async def write_tesla_data(self, points: list) -> None:
         valid_points = [p for p in points if p is not None]
         if len(valid_points) == 0:

--- a/backend/src/tesla_service/start_tesla_services.py
+++ b/backend/src/tesla_service/start_tesla_services.py
@@ -72,6 +72,38 @@ def _history_range(range_code: int, start_ms: int, end_ms: int) -> tuple:
     return time_start, time_end
 
 
+# Preset window widths in milliseconds, kept beside the _history_range strings so
+# the empty-window boundary-fill spans exactly the same range the query asked for.
+_PRESET_WINDOW_MS = {
+    _RANGE_1H: 60 * 60 * 1000,
+    _RANGE_1D: 24 * 60 * 60 * 1000,
+    _RANGE_1W: 7 * 24 * 60 * 60 * 1000,
+    _RANGE_1M: 30 * 24 * 60 * 60 * 1000,
+}
+
+
+def _history_bounds_ms(range_code: int, start_ms: int, end_ms: int) -> tuple:
+    '''
+    Returns the requested window's [start, end] as epoch-ms — the absolute
+    counterpart to _history_range's Flux strings. Used only to position the two
+    synthetic boundary points when a window logged nothing, so the flat held line
+    spans the whole selected range. Presets end at "now"; a custom range echoes its
+    bounds; anything malformed falls back to the last hour (matching _history_range).
+    Arguments:
+        range_code (int): One of the _RANGE_* codes.
+        start_ms (int): Custom-range start (epoch ms); ignored for presets.
+        end_ms (int): Custom-range end (epoch ms); ignored for presets.
+    Returns:
+        tuple[int, int]: (start_ms, end_ms) in epoch milliseconds.
+    '''
+    now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+    if range_code in _PRESET_WINDOW_MS:
+        return now_ms - _PRESET_WINDOW_MS[range_code], now_ms
+    if range_code == _RANGE_CUSTOM and start_ms > 0 and end_ms > start_ms:
+        return start_ms, end_ms
+    return now_ms - _PRESET_WINDOW_MS[_RANGE_1H], now_ms
+
+
 def _build_history_frame(data_property_id: str, result) -> bytes:
     '''
     Builds a TESLA_HISTORY response frame. The echoed id lets the frontend drop
@@ -144,6 +176,24 @@ def _register_handlers(
             result = await vehicle.get_data_history(
                 data_property_id, time_start, time_end
             )
+            if result is None:
+                # Genuinely-empty window (the value stayed constant, so nothing was
+                # logged in range): draw a flat held line spanning the whole selected
+                # range from the last value before the window. If there is no prior
+                # value — or InfluxDB is down, where this query also returns None —
+                # we fall through to a status=0 "no data" frame and never fabricate.
+                window_start_ms, window_end_ms = _history_bounds_ms(
+                    range_code, start_ms, end_ms
+                )
+                window_start_rfc = (
+                    datetime.fromtimestamp(window_start_ms / 1000, tz=timezone.utc)
+                    .isoformat().replace("+00:00", "Z")
+                )
+                held = await vehicle.get_value_before(
+                    data_property_id, window_start_rfc
+                )
+                if held is not None:
+                    result = (2, [window_start_ms, window_end_ms], [held, held])
         except ValueError as e:
             # Malformed id / window — reply empty rather than dropping the request.
             logger.warning("TESLA_GET_HISTORY rejected: %s", e)

--- a/backend/src/tesla_service/vehicle.py
+++ b/backend/src/tesla_service/vehicle.py
@@ -486,6 +486,20 @@ class Vehicle:
             data_property_id, time_start, time_end, aggregate_window
         )
 
+    async def get_value_before(self, data_property_id: str, stop_time: str):
+        '''
+        Returns the last stored value of a property strictly before stop_time, or
+        None. Used by the History path to draw a flat held line for a window that
+        logged nothing (a constant value). Vehicle owns Influx access, so the
+        handler reaches it through here rather than the InfluxDBHandler directly.
+        Arguments:
+            data_property_id (str): The property id to look up.
+            stop_time (str): Flux range stop (code-generated RFC3339).
+        '''
+        return await self.__influx_handler.read_last_value_before(
+            data_property_id, stop_time
+        )
+
     async def __rate_limit_reserve(self) -> bool:
         '''
         Atomically checks the rate-limit window and, if a slot is available,

--- a/frontend_v2/core/tesla/teslahistory.cpp
+++ b/frontend_v2/core/tesla/teslahistory.cpp
@@ -45,6 +45,22 @@ qint64 TeslaHistory::windowMsForRange(int rangeCode) {
     }
 }
 
+int TeslaHistory::liveTickIntervalForRange(int rangeCode) {
+    // Throttle the live tick by window size. The tick both samples the live value
+    // and advances the right edge, so its period is also the redraw rate AND the
+    // value-sampling resolution. On the long windows a 1 s advance is sub-pixel, so
+    // we slow the tick down to keep the per-tick full series rebuild from stuttering
+    // on the Pi — subsampling value changes to a resolution that is imperceptible at
+    // that zoom (a 30 s step on a 30-day axis).
+    switch (rangeCode) {
+        case protocol::HISTORY_RANGE_1H: return 1000;   // 1 s — responsive on a 1 h axis
+        case protocol::HISTORY_RANGE_1D: return 5000;   // 5 s
+        case protocol::HISTORY_RANGE_1W: return 10000;  // 10 s
+        case protocol::HISTORY_RANGE_1M: return 30000;  // 30 s
+        default: return 1000;  // custom/unknown -> 1 s
+    }
+}
+
 void TeslaHistory::startLive(const QString &id, int rangeCode) {
     if (id.isEmpty()) {
         return;
@@ -57,6 +73,10 @@ void TeslaHistory::startLive(const QString &id, int rangeCode) {
     m_liveId = id;
     m_liveRangeCode = rangeCode;
     m_liveWindowMs = windowMsForRange(rangeCode);
+    // Throttle the per-second rebuild on long windows (see liveTickIntervalForRange).
+    // The timer is (re)started in parseHistory once the seed lands; setting the
+    // interval here applies on that start.
+    m_liveTimer->setInterval(liveTickIntervalForRange(rangeCode));
     // Seed from history; the per-second timer starts once the matching reply lands
     // (see parseHistory), so the rolling window begins from real stored data.
     requestHistory(id, rangeCode, 0.0, 0.0);

--- a/frontend_v2/core/tesla/teslahistory.hh
+++ b/frontend_v2/core/tesla/teslahistory.hh
@@ -91,6 +91,7 @@ private:
     // Live helpers.
     static QString qmlNameForId(const QString &id);  // id -> Tesla Q_PROPERTY name
     static qint64 windowMsForRange(int rangeCode);   // preset -> window width (ms)
+    static int liveTickIntervalForRange(int rangeCode);  // preset -> live tick period (ms)
     void recomputeBounds(qint64 nowMs);              // roll window + recompute min/max
 
     ServerClient *m_server;


### PR DESCRIPTION
Resolves the two open History-graph follow-up issues. Both verified working by the user; the branch is a clean fast-forward over `main` (no divergence, no conflicts).

## Changes

### Fix: boundary-fill empty History windows with a flat held line (closes #3)
When a property logged nothing within the selected window (its value stayed constant), the backend returned 0 points and the graph showed "Ei dataa". Now:
- `InfluxDBHandler.read_last_value_before(id, stop_time)` — a `last()` query for the held value just before the window start.
- `Vehicle.get_value_before(...)` — passthrough (vehicle owns Influx access).
- `start_tesla_services._get_history` — when the window is empty, returns **two synthetic points** (window-start + window-end at that held value) so the step line draws a flat line across the whole selected range.

Only a genuinely absent prior value — or an InfluxDB outage, where the boundary query also yields nothing — still replies `status=0`. Scoped to the empty-window case, so non-empty windows keep their existing data-extent rendering. Backend-only; no frontend change.

### Add: throttle the live History tick on long windows (closes #2)
The live graph rebuilt the full stepped series every second; on 1-week / 1-month windows a many-point seed risked stuttering on the Raspberry Pi.
- `TeslaHistory::liveTickIntervalForRange(rangeCode)` scales the tick interval by window — 1h→1s, 1d→5s, 1w→10s, 1M→30s (custom/unknown→1s); `startLive` applies it.

Cuts the 1M full-series rebuild from 60/min to ~2/min. The tick is also the value sampler, so a longer period subsamples value changes — but at 1w/1M zoom a 30 s step is sub-pixel and imperceptible. Throttle-only (incremental trailing-edge redraw deferred). `frontend_v2` C++ only, no QML change.

### Docs
CLAUDE.md §5.1 / §5.2.2 / §5.2.5 updated for the boundary-fill; §7.7 currency marker bumped. The live-tick throttle is recorded in the `frontend_v2` architecture notes (out of scope for CLAUDE.md).

## Manual verification
- **#3:** open the History view on a property constant over the selected window → flat line spanning the full range instead of "Ei dataa".
- **#2:** rebuild `frontend_v2`, open the live graph on 1w/1M → smooth; validated with `qmlprofiler` on the Pi.
- Backend: `python -m compileall backend/src` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)