### PR TITLE
Fix: retint Trips view dropdowns grey to match card family

### DIFF
--- a/frontend_v2/app/Theme.qml
+++ b/frontend_v2/app/Theme.qml
@@ -99,12 +99,13 @@ QtObject {
     readonly property color tripControlBar: "#cc1b2230"
     readonly property color tripControlBarBorder: "#33ffffff"
     // Dark-themed ComboBox (week/trip selectors) so the dropdown never flashes the
-    // Basic style's light popup/hover square over the map. Field + popup are dark;
-    // the hover highlight is a muted blue-grey (NOT white).
-    readonly property color tripComboBg: "#66222a3a"
-    readonly property color tripComboPressed: "#99222a3a"
-    readonly property color tripComboPopupBg: "#f21b2230"
-    readonly property color tripComboHover: "#55617a"
+    // Basic style's light popup/hover square over the map. Neutral dark grey so the
+    // dropdowns match the translucent-grey card family (tripCardBg) rather than
+    // clashing as blue; the hover highlight is the card grey (NOT white).
+    readonly property color tripComboBg: "#662c2c2c"
+    readonly property color tripComboPressed: "#992c2c2c"
+    readonly property color tripComboPopupBg: "#f2242424"
+    readonly property color tripComboHover: "#5c5c5c"
     // Start/end route markers: a map-red so they read as pins, distinct from the
     // green→red speed gradient of the route line (the pin shape disambiguates).
     readonly property color tripMarkerColor: "#ff3b30"


### PR DESCRIPTION
## Summary
The week and trip selection dropdowns in the Trips view ("Matkat") rendered as **dark translucent blue**, while every other surface in that view — the stat cards, the map/graph frames, and the selector card itself — is **dark translucent grey** (`tripCardBg`). The dropdowns clashed with everything around them.

This retints the four `tripCombo*` tokens in `frontend_v2/app/Theme.qml` from blue to neutral dark grey so the dropdowns join the grey card family. All three Trips dropdowns (`WeekSelector`, `TripSelector`, and the shared `TripPropertySelector`) go through `TripComboBox`, so this fixes them together and keeps them consistent.

| Token | Before (blue) | After (grey) |
|---|---|---|
| `tripComboBg` (field) | `#66222a3a` | `#662c2c2c` |
| `tripComboPressed` | `#99222a3a` | `#992c2c2c` |
| `tripComboPopupBg` (open menu) | `#f21b2230` | `#f2242424` |
| `tripComboHover` (row highlight) | `#55617a` | `#5c5c5c` (card grey) |

The original alpha/luminance is preserved, so only the hue shifts — the dropdowns keep their visual weight. The hover row now uses `#5c5c5c`, the exact grey of `tripCardBg`. Borders were left as-is (`tripControlBarBorder` `#33ffffff`, a faint white — not blue, so no clash).

## Reason
Visual inconsistency reported: the dropdowns looked blue against an otherwise grey Trips view.

## Manual verification
- Rebuild `frontend_v2` and open the Trips view.
- Confirm the closed week/trip dropdown fields read as dark grey, consistent with the surrounding cards (no blue tint).
- Open each dropdown and confirm the popup background is dark grey and the hover/highlight row is grey (not blue, not white).

## Screenshots
_To be added after local rebuild._