### PR TITLE
Add: home charger (Zappi) integration + Charging (Lataus) view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,13 @@ backend/
         spotify_setup.py          # Standalone OAuth + Connect-device-ID helper (run once during setup)
     weather_service/
       weather_service.py          # FMI WFS polling, forecast serialization, 15-min refresh
+    trip_service/
+      trip.py, trip_loader.py     # On-demand trip detection from stored telemetry (the Trips view)
+    charging_service/
+      charging_loader.py          # On-demand charging-session detection (DetailedChargeState segmentation)
+      charging_session.py         # Per-session energy + loss breakdown (charger vs AC-in vs battery)
+    myenergi_service/
+      myenergi_service.py         # myenergi Zappi cloud poll → CHARGER_STREAM broadcast + myenergi_data logging
     influxdb_service/
       influxdb_handler.py         # Async InfluxDB client — telemetry write + Flux history reads
     utils/
@@ -125,6 +132,10 @@ The backend is an asyncio app managed with [uv](https://docs.astral.sh/uv/). Run
 Dev environment: **Ninja + Qt 6.11.1 MSVC2022**. CMake ships with Qt at
 `D:\Qt\Tools\CMake_64\bin\cmake.exe`. The build directory is **`frontend/builddir`**.
 
+> This section covers the frozen Widgets `frontend/`. For the active **`frontend_v2`**, prefer
+> `scripts\build-frontend.ps1` — it imports the MSVC env, finds the Qt kit, and configures + builds
+> (+ optionally runs) in one command, with sccache reuse. See §8.
+
 - **Configure** (required once before the first build, and after CMakeLists changes):
 
   ```
@@ -167,7 +178,9 @@ Required secrets/paths, loaded by `utils/config_parser.get_env`:
 - `INFLUX_TOKEN` — InfluxDB auth token
 - `SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET` — from your Spotify Developer App
 
-`start_services.main()` fails fast if any of these are missing.
+`start_services.main()` fails fast if any of these are missing. **Optional:** `MYENERGI_HUB_SERIAL`
+/ `MYENERGI_API_KEY` (myenergi cloud digest-auth creds) — absent → the charger service is skipped
+and the rest of the stack still runs.
 
 ### `config.json` (copy from `config_template.json`)
 Parsed once by `Config` and injected into every service. Keys:
@@ -182,6 +195,12 @@ Parsed once by `Config` and injected into every service. Keys:
   (default `http://127.0.0.1:8080/callback`, must match the Spotify app); `spotifyCachePath`
   — spotipy OAuth token cache; `spotifyMarket` — ISO-3166-1 alpha-2 (e.g. `FI`).
 - `weatherPlace` — FMI place (e.g. `Tampere`); `timeZone` — IANA zone (e.g. `Europe/Helsinki`).
+- `myenergi` (optional) — Zappi tunables: `zappiSerial` (`""` = auto-select the first Zappi),
+  `pollIntervalIdleSeconds` / `pollIntervalActiveSeconds`, `minSessionEnergyKwh`, `sessionMergeMinutes`.
+- `trip` (optional) — trip-detection tunables: `min_stop_minutes`, `min_trip_distance_km`.
+- `electricityPriceEurPerKwh` (optional) — flat €/kWh tariff for the Charging view's cost tiles
+  (`Latauskulut` = charging cost, `Sähkölasku` = total home electricity cost); `null`/absent → "—".
+  Spot/hourly (Nord Pool) pricing is tracked in issue #12.
 
 ### Frontend environment variables (read only by `AppConfig::load()`)
 All optional; defaults match the embedded target.
@@ -238,6 +257,18 @@ payload[1..N-1] = type-specific data
 | `0x71` | TESLA_GRAPH_PROPERTIES | B→F | `count(2B)` + per property `id_len(2B)+id + unit_len(2B)+unit + cat_len(2B)+category` (UTF-8) |
 | `0x72` | TESLA_GET_HISTORY | F→B | `range_code(1B)` (0=1h,1=1d,2=1M,3=custom,4=1week) + `id_len(2B)+id` + `start_ms(8B)` + `end_ms(8B)` |
 | `0x73` | TESLA_HISTORY | B→F | `id_len(2B)+id` + `status(1B)` + `count(4B)` + count×(`ts_ms(8B)` + `value(8B double)`) |
+| `0x50` | CHARGER_STREAM | B→F | myenergi charger live state: repeated `sub_id(1B) + value` (see charger sub-ids below) |
+| `0x80` | CHARGING_GET_LIST | F→B | `start_ms(8B) + end_ms(8B)` |
+| `0x81` | CHARGING_LIST | B→F | `req_start(8B)+req_end(8B)+count(2B)` + count×(`start(8B)+end(8B)+charger_kwh(8B double)`) |
+| `0x82` | CHARGING_GET_SUMMARY | F→B | `start_ms(8B) + end_ms(8B)` |
+| `0x83` | CHARGING_SUMMARY | B→F | `session_id(8B)+status(1B)+start(8B)+end(8B)` + 9×`double` (per-session losses) |
+| `0x84` | CHARGING_GET_MONTH | F→B | (empty) |
+| `0x85` | CHARGING_MONTH | B→F | `status(1B)` + 13×`double` (month aggregate — see below) |
+| `0x86` | CHARGER_GET_HISTORY | F→B | `range_code(1B) + id_len(2B)+id + start_ms(8B) + end_ms(8B)` |
+| `0x87` | CHARGER_HISTORY | B→F | `id_len(2B)+id + status(1B) + count(4B)` + count×(`ts_ms(8B)+value(8B double)`) — reads `myenergi_data` |
+
+(Trip codes `0x74`–`0x7D` — the Trips view — are omitted from this table; they mirror the History
+request/response shape. See the `frontend_v2` memory.)
 
 The `0x70`–`0x73` pair is **request/response** (the History view): the backend replies to the
 requesting client only (`send_to`), never a broadcast, and `TESLA_HISTORY` echoes the requested id so
@@ -255,6 +286,18 @@ flat held line across the whole range instead of "no data". Only a genuinely abs
 
 **Weather sub-IDs**: `0x31` temperature `int8` °C; `0x32` wind `uint8` m/s;
 `0x33` precipitation `uint8` mm; `0x34` cloud cover `uint8` %; `0x35` hour `uint8`.
+
+**Charger (myenergi) protocol** — the Charging view. `CHARGER_STREAM` (`0x50`) is a **broadcast** of
+the Zappi's live state, a weather-style sequence of `sub_id(1B) + value` pairs: `0x51` status `uint8`,
+`0x52` plug `uint8`, `0x53` mode `uint8`, `0x54` charge power `float64` W, `0x55` session energy
+`float64` kWh, `0x56` supply voltage `uint16` V, `0x57` grid power `float64` W (+import/−export),
+`0x58` generated power `float64` W, `0x59` frequency `float64` Hz, `0x5A` L1 phase `uint8`, and
+`0x5F` the full raw pymyenergi payload as `len(4B)+UTF-8 JSON` (every field, most unused — the one
+length-prefixed sub-id, so an unknown fixed-width sub-id can't be skipped and stops the parse). The
+`0x80`–`0x87` codes are **request/response** (reply to the requesting client only), served by
+`charging_service` from stored telemetry + `myenergi_data`. `CHARGING_MONTH`'s 13 doubles, in order:
+charger_kwh, car_kwh, wasted_kwh, efficiency_pct, car_wh_per_km, charger_wh_per_km, driving_kwh,
+km_month, session_count, total_charge_s, charging_cost_eur, home_grid_kwh, home_cost_eur (any → NaN → "—").
 
 **Adding a telemetry field** — update these in sync:
 1. `config.json` `tesla data` — new entry with a unique `stream_id`.
@@ -275,8 +318,10 @@ flat held line across the whole range instead of "no data". Only a genuinely abs
 
 The backend is entirely asyncio. `start_services.main()` constructs every service,
 calls `_register_handlers` and `register_service` on the `Server`, runs
-`vehicle.init_async_dependent()`, then **`asyncio.gather`s four tasks**: telemetry, the TCP
-server, `MediaManager.get_run_task()`, and `WeatherService.get_run_task()`.
+`vehicle.init_async_dependent()`, then **`asyncio.gather`s the run tasks**: telemetry, the TCP
+server, `MediaManager.get_run_task()`, `WeatherService.get_run_task()`, and — when charger
+credentials are set — `MyEnergiService.get_run_task()`. (`trip_service` / `charging_service` are
+stateless request/response and have no run task.)
 
 > **Orchestration note.** The media and weather `run()` coroutines schedule APScheduler jobs
 > and then *return* — their ongoing work lives in those jobs, and APScheduler logs+swallows
@@ -392,8 +437,11 @@ snapshot), `read_first_value_day`/`_month` (calculated-field baselines), `read_t
 `aggregateWindow(fn: mean) + fill(usePrevious)` to downsample + forward-fill onto a regular grid,
 dropping the leading null windows, but is currently unused), and `read_last_value_before` (a
 `last()` query bounded by `stop` — the held value before an empty window, used to boundary-fill the
-History graph with a flat line). Read failures degrade to `None` rather
-than crashing the app. **Talks to:** InfluxDB,
+History graph with a flat line). For the myenergi charger it adds `write_charger_data` (the
+`myenergi_data` measurement), `read_charger_data_property` (raw charger history), and
+`read_grid_import_kwh_month` (a positive-`GridPower` `integral()` → the month's home grid import;
+`integral()` needs the range's `_start` column, so do **not** `keep()`-drop columns before it). Read
+failures degrade to `None` rather than crashing the app. **Talks to:** InfluxDB,
 `Vehicle`. *Flux queries interpolate `data_property_id` via f-strings gated by the `_SAFE_ID` regex
 `^[A-Za-z0-9_\-]+$`, and `aggregate_window` by `_SAFE_WINDOW` (`^[1-9][0-9]*[smhd]$`) — keep both
 guards; they're the only thing preventing injection if non-config input ever reaches these paths.*
@@ -403,7 +451,28 @@ guards; they're the only thing preventing injection if non-config input ever rea
 - **`protocol.py`**: every message-type byte, weather sub-id, `MAX_MSG_SIZE`, and `frame()`. The
   single source of truth — add new constants here, never on a class.
 - **`logger_configurator.py`**: `configure_logging` wires the shared stdout formatter
-  (`LEVEL | YYYY-MM-DD | HH:MM:SS | name | message`).
+  (`LEVEL | YYYY-MM-DD | HH:MM:SS | name | message`) onto an allow-list of top-level loggers.
+  **Every service's logger prefix must be in `_SERVICE_LOGGERS`** (`tesla_service`, `media_service`,
+  `weather_service`, `influxdb_service`, `charging_service`, `myenergi_service`, `trip_service`,
+  `server`, `start_services`, `utils`) — an unlisted prefix propagates to a handler-less root and its
+  INFO/DEBUG logs silently vanish.
+
+#### 5.2.7 `myenergi_service/` + `charging_service/` — charger + charging stats
+- **`myenergi_service.py`** (`MyEnergiService`) polls a myenergi Zappi via `pymyenergi` (cloud
+  digest auth), broadcasts its live state as `CHARGER_STREAM`, and logs to the `myenergi_data`
+  measurement: `GridPower` + `ChargePower` **every poll** (gap-free for the past-hour graphs and the
+  month home-import integral) and `ChargeAdded` (the session accumulator) **while charging**. Mirrors
+  `WeatherService` (initial poll + APScheduler job, last frame cached for `stream_everything`), with
+  two poll cadences (idle/active). Optional — skipped when the `.env` creds are unset.
+- **`charging_service/`** (`ChargingLoader` + `ChargingSession`) derives charging sessions **on
+  demand** from stored `DetailedChargeState` history (segmentation like `trip_service`), joined to
+  the logged charger energy — no live tracking. Serves `CHARGING_GET_LIST`/`_SUMMARY`/`_MONTH` +
+  `CHARGER_GET_HISTORY`. **Per-session charger energy = the SUM OF POSITIVE `ChargeAdded` increments
+  in the window** (NOT the in-window max: the myenergi accumulator can carry a value in from charging
+  that predates the Tesla-detected session, so a max double-counts — this was a real bug). `month_summary`
+  sums the sessions' charger/battery energy + the tesla month-counter deltas (`LifetimeEnergyUsed`,
+  `Odometer`) for consumption/km; the `CHARGING_GET_MONTH` handler multiplies energy by the flat
+  `electricityPriceEurPerKwh` tariff for the cost tiles. **Talks to:** `InfluxDBHandler`, `Server`.
 
 ### 5.3 Frontend
 
@@ -577,57 +646,66 @@ a new/renamed service or widget, a protocol change, a build-command change, or a
 invariant. Treat the doc as part of the change, not an afterthought, and bump §7.7.
 
 ### 7.7 Documentation currency
-This guide and `README.md` are current as of commit **`1184b60`** ("Add: throttle the live History
-tick on long windows"), which — together with the preceding **`cc11bb8`** ("Fix: boundary-fill empty
-History windows with a flat held line") — adds the History-graph **empty-window boundary-fill**
-(`read_last_value_before` / `get_value_before`; a constant-value window now draws a flat line instead
-of "Ei dataa"). The earlier interactive **History-graph view** (commit `827824d`) lands the
-`0x70`–`0x73` request/response protocol, the `(payload, writer)` handler signature, history **range
-code 4 = 1 week**, and the Qt 6.11 build. The frontend-only live-graph mode (and its per-window tick
-throttle) rides on these codes — out of scope here; see the `frontend_v2` memory.
+This guide and `README.md` are current as of commit **`966a04a`** ("Add: fixed-price electricity
+cost"), the head of the **charging-stats** work on `feature/charging-stats-backend`: the myenergi
+Zappi integration (`myenergi_service`, `CHARGER_STREAM` `0x50`, `myenergi_data` logging), the
+on-demand **charging-session analysis** (`charging_service`; `CHARGING_*` / `CHARGER_HISTORY`
+`0x80`–`0x87`), the **month-to-date aggregate** (`CHARGING_MONTH`, 13 doubles) and the **flat-tariff
+cost tiles** (`electricityPriceEurPerKwh`; spot pricing is issue #12). Per-session charger energy is
+the **sum of positive `ChargeAdded` increments** (not the in-window max — that double-counted). The
+frontend_v2 "Lataus" view consumes these (out of scope here; see the `frontend_v2` memory). The
+earlier History-graph **empty-window boundary-fill** (`1184b60` / `cc11bb8`) and the `0x70`–`0x73`
+request/response protocol + `(payload, writer)` handler signature (`827824d`) still apply.
 When you land changes that touch behaviour documented here, update this line to the new HEAD commit.
 
-## 8. Session workflow — one worktree per session
+## 8. Session workflow — main checkout by default, worktree only for parallelism
 
-Parallel Claude Code sessions (or a session running alongside your own manual work) must not
-share a working tree: simultaneous edits, competing git operations, and the single backend port
-**6969** will collide. So each **work session gets its own git worktree on its own branch** and
-lands via a pull request. Pure Q&A / exploration that changes no files skips all of this.
+The default is to **work in the main checkout** (`P:\Tesla-Homedash`). An isolated git worktree is
+only worth its setup cost when you genuinely need **two sessions running at the same time** — reach
+for one *only then*. Most sessions are sequential and stay in the main checkout with a warm build
+dir and incremental builds. Pure Q&A / exploration that changes no files needs neither.
 
-**Start of a work session — ask first, then isolate.**
-1. Before touching files, ask the user two things: **(a) what are we doing this session** and
-   **(b) a short name for it.** Choose the branch **type** from the nature of the work
-   (`feature` / `fix` / `chore` / `docs` / `refactor` / `test` / `perf`); confirm if unsure.
-2. Create the worktree + branch:
-   `powershell -ExecutionPolicy Bypass -File scripts\new-session.ps1 -Type <type> -Name "<name>"`
-   It makes branch `<type>/<slug-of-name>` off the freshest `origin/main`, adds a worktree under
-   `..\Tesla-Homedash-worktrees\<type>-<slug>`, copies the gitignored `.env` + `config.json` into
-   it, and repoints that `.env`'s `CONFIG_PATH` at the worktree's own `config.json`. The final
-   stdout line is `WORKTREE_PATH=<path>`.
-3. Switch the session into it with the **`EnterWorktree`** tool (`path:` = that `WORKTREE_PATH`).
-   From here every edit / build / commit happens in the worktree, isolated from `main` and from
-   any other session.
+**Backend — run one, shared.** The frontend connects to whatever backend is on `127.0.0.1:6969`
+(`TESLA_HOMEDASH_BACKEND_HOST` / `_PORT` default there), and port 6969 is fixed so only **one**
+backend can run at a time. Start it **once** (from the main checkout: `cd backend; uv run python
+run.py`) and leave it — every frontend, in any checkout, connects to it. Do **not** start a backend
+per session. Only a session that actually edits backend code runs its own, and it stops the shared
+one first.
 
-**During the session** — work as normal, entirely within the worktree. `frontend_v2` needs a
-fresh CMake configure in the worktree before its first build (build dirs are not copied). The
-backend runs standalone there (its `.env` / `config.json` were copied in), but only **one**
-session at a time can run the live backend — port 6969 is fixed, so never run two live stacks.
+**Frontend — build from the CLI, no Qt Creator needed.** Build + run `frontend_v2` with
+`powershell -ExecutionPolicy Bypass -File scripts\build-frontend.ps1 -Run` (add `-Clean` for a full
+rebuild, `-Config Release`, `-Fullscreen`). From **cmd.exe** use the `.cmd` shim instead:
+`scripts\build-frontend.cmd -Run` (same for `new-session.cmd` / `finish-session.cmd`). It imports the MSVC env, finds the newest Qt
+`msvc2022_64` kit, and runs a Ninja configure + build of `appfrontend_v2` into `frontend_v2\build`
+— works from the main checkout or any worktree. Open Qt Creator only when you need the debugger /
+QML profiler / designer. **sccache** is wired into `frontend_v2/CMakeLists.txt` (auto-enabled when
+on PATH), so object files are reused across rebuilds *and across worktrees* — a fresh worktree's
+"clean" build is mostly cache hits. Inspect with `sccache --show-stats`. (Per §7.3 the agent still
+doesn't build; it reasons about the code and the user runs the script.)
 
-**Finish — open a PR, then land via GitHub (never a local merge).**
-1. Commit per §7.5 (still only once the user confirms the work is verified), then push:
+**When you *do* need a parallel session (worktree).**
+1. Ask the user **(a) what we're doing** and **(b) a short name**; choose the branch **type**
+   (`feature` / `fix` / `chore` / `docs` / `refactor` / `test` / `perf`).
+2. `powershell -ExecutionPolicy Bypass -File scripts\new-session.ps1 -Type <type> -Name "<name>"`
+   — makes branch `<type>/<slug>` off the freshest `origin/main`, adds a worktree under
+   `..\Tesla-Homedash-worktrees\<type>-<slug>`, copies the gitignored `.env` + `config.json` in, and
+   repoints `CONFIG_PATH` at the worktree's copy. Final stdout line: `WORKTREE_PATH=<path>`.
+3. Switch in with the **`EnterWorktree`** tool (`path:` = that `WORKTREE_PATH`). Build there with
+   `build-frontend.ps1`; connect to the already-running shared backend (don't start a second one).
+
+**Finish — land via GitHub, never a local merge** (applies whether you used a branch or a worktree).
+1. Commit per §7.5 (only once the user confirms the work is verified), then
    `git push -u origin <type>/<slug>`.
-2. Open the PR with a proper body (summary, reason, manual verification steps, UI screenshots)
-   per §7.5 — e.g. `gh pr create` with the body inline.
-3. After review, merge **on GitHub**: `gh pr merge --squash --delete-branch`. GitHub is the
-   single source of truth — **do not** merge the branch into `main` locally; that diverges local
-   `main` from `origin/main` and makes the PR redundant.
-4. Return + clean up: call **`ExitWorktree`** (action `keep`) to leave the worktree, then
-   `powershell -ExecutionPolicy Bypass -File scripts\finish-session.ps1 -Type <type> -Name "<name>"`.
-   It refuses until the PR reads MERGED (checked via `gh`), then removes the worktree,
-   `checkout main && pull` on the main checkout, deletes the merged local branch, and prunes.
-   (`-Force` skips the merged check for edge cases.)
+2. Open the PR with a proper body (summary, reason, manual verification, UI screenshots) per §7.5.
+3. Merge **on GitHub**: `gh pr merge --squash --delete-branch`. GitHub is the single source of
+   truth — **do not** merge into `main` locally (it diverges local `main` from `origin/main`). Then
+   update the main checkout: `git checkout main && git pull`.
+4. If a worktree was used: `ExitWorktree` (action `keep`), then
+   `powershell -ExecutionPolicy Bypass -File scripts\finish-session.ps1 -Type <type> -Name "<name>"`
+   — refuses until the PR reads MERGED (via `gh`), then removes the worktree, pulls main, deletes the
+   merged local branch, and prunes. (`-Force` skips the merged check.)
 
-**Memory caveat.** This project's memories load at session start from the main checkout, *before*
-you switch, so their guidance stays in context for the whole session. But the memory *store*
-follows the working directory, so any durable memory you write during a worktree session must
-target the **main checkout's** project-memory dir, not the worktree's (which is deleted at cleanup).
+**Memory caveat.** Memories load at session start from the main checkout, so their guidance stays in
+context even after an `EnterWorktree`. But the memory *store* follows the working directory, so any
+durable memory you write during a worktree session must target the **main checkout's** project-memory
+dir, not the worktree's (which is deleted at cleanup).

--- a/backend/src/charging_service/charging_loader.py
+++ b/backend/src/charging_service/charging_loader.py
@@ -131,14 +131,20 @@ def segment_sessions(
     return windows
 
 
-def _window_max(charger, window_start_ms: int, window_end_ms: int) -> float:
+def _window_energy(charger, window_start_ms: int, window_end_ms: int) -> float:
     '''
     Computes a session window's charger energy (kWh) from an already-read ChargeAdded
-    series, without another query: the maximum sample inside [window_start, window_end]
-    (ChargeAdded is an accumulator that ramps from 0 to the session total). NaN when the
-    series is missing or holds no sample inside the window (a session at another
-    charger) — matching the per-session read's NaN so min-energy filtering behaves
-    identically. The charging analogue of trip_service._window_distance.
+    series, without another query: the SUM OF POSITIVE INCREMENTS of the accumulator
+    inside [window_start, window_end]. ChargeAdded ramps up as energy is delivered and
+    only drops when the myenergi charger begins a new session, so summing its positive
+    steps is the energy actually delivered in the window — robust to the accumulator
+    CARRYING a non-zero value into the window (a physical charge whose start Tesla did not
+    yet report as "charging", so it falls outside the detected session) or RESETTING
+    inside it. The earlier in-window MAX over-counted both cases by the carried/earlier
+    peak (e.g. a 16.6 kWh session that had only delivered 5.6 kWh in its window). NaN when
+    the series is missing or holds fewer than two samples in the window (nothing to
+    difference — e.g. a session at another charger), matching the old NaN so the
+    min-energy filter still drops those. The charging analogue of _window_distance.
     Arguments:
         charger (tuple | None): (count, timestamps_ms, values) from
             read_charger_data_property(ChargeAdded, ...), ascending by time, or None.
@@ -151,10 +157,11 @@ def _window_max(charger, window_start_ms: int, window_end_ms: int) -> float:
     if count == 0 or len(values) == 0:
         return float("nan")
     low = int(np.searchsorted(timestamps, window_start_ms, side="left"))
-    high = int(np.searchsorted(timestamps, window_end_ms, side="right")) - 1
-    if low > high or low >= count or high < 0:
+    high = int(np.searchsorted(timestamps, window_end_ms, side="right"))
+    segment = values[low:high]
+    if len(segment) < 2:
         return float("nan")
-    return float(values[low:high + 1].max())
+    return float(np.clip(np.diff(segment), 0.0, None).sum())
 
 
 class ChargingLoader:
@@ -226,7 +233,7 @@ class ChargingLoader:
 
         sessions = []
         for window_start, window_end, in_progress in windows:
-            charger_kwh = _window_max(charger, window_start, window_end)
+            charger_kwh = _window_energy(charger, window_start, window_end)
             # Drop sub-threshold and no-charger-data sessions: the losses view is about
             # THIS charger, so a session with no comparable Zappi energy (charged
             # elsewhere / DC) or a trivial top-up is not listed. NaN < threshold is

--- a/backend/src/charging_service/charging_loader.py
+++ b/backend/src/charging_service/charging_loader.py
@@ -19,6 +19,12 @@ from .charging_session import CHARGER_ENERGY_ID, ChargingSession, to_flux_time
 
 logger = logging.getLogger("charging_service.charging_loader")
 
+# Tesla lifetime counters read for the month-to-date consumption figures — the same ids
+# and first-of-month baseline DrivenThisMonth uses. Odometer is stored in km (its formula
+# is applied on write); LifetimeEnergyUsed is stored raw in kWh.
+ODOMETER_ID = "Odometer"
+DRIVING_ENERGY_ID = "LifetimeEnergyUsed"
+
 
 def _is_charging(state: str) -> bool:
     '''
@@ -259,3 +265,126 @@ class ChargingLoader:
             return None
         session = ChargingSession(self.__influx, start_ms, end_ms)
         return await session.summary()
+
+    async def get_power_history(self, data_property_id: str, time_start: str, time_end: str):
+        '''
+        Reads a logged charger power series (e.g. GridPower / ChargePower) raw over a
+        window, for the Charging view's past-hour graphs — a thin pass-through to the
+        InfluxDBHandler's myenergi_data read, kept here so the charger-history request
+        handler has one charging-data entry point (the loader owns all myenergi_data
+        access). Raises ValueError on a malformed id (the read's _SAFE_ID guard) — the
+        handler replies status=0.
+        Arguments:
+            data_property_id (str): The charger property id (InfluxDB "id" tag).
+            time_start (str): Flux range start (relative like "-1h" or RFC3339).
+            time_end (str): Flux range stop ("now()" or RFC3339).
+        Returns:
+            tuple | None: (count, timestamps_ms, values) ascending, or None.
+        '''
+        return await self.__influx.read_charger_data_property(
+            data_property_id, time_start, time_end
+        )
+
+    async def month_summary(self, start_ms: int, end_ms: int) -> dict:
+        '''
+        Aggregates the month-to-date charging stats for the Charging view. Sums the
+        myenergi-detected sessions in [start_ms, end_ms] (via list_sessions + each
+        session's summary()), so charger vs car energy stay apples-to-apples over the same
+        session set. Distance and driving energy are the tesla lifetime counters' month
+        deltas (Odometer / LifetimeEnergyUsed, the same first-of-month baseline
+        DrivenThisMonth uses); the home grid import is the month integral of positive
+        GridPower. Every field degrades to NaN when its source is missing, so a partial-
+        data month still yields a well-formed record. Cost is added by the request handler
+        (it owns the tariff).
+        Arguments:
+            start_ms (int): Month start (1st, 00:00 local), epoch-ms UTC.
+            end_ms (int): Now, epoch-ms UTC.
+        Returns:
+            dict: The month aggregate (energy, waste, efficiency, consumption/km,
+                sessions, charge time, home import), each value a float (may be NaN).
+        '''
+        sessions = await self.list_sessions(start_ms, end_ms)
+
+        charger_sum = 0.0
+        battery_sum = 0.0
+        battery_count = 0
+        charge_time_s = 0.0
+        for session in sessions:
+            summary = await session.summary()
+            # list_sessions already dropped NaN-charger sessions, so charger_kwh is real.
+            charger_sum += summary["charger_kwh"]
+            battery_kwh = summary["battery_kwh"]
+            if not math.isnan(battery_kwh):
+                battery_sum += battery_kwh
+                battery_count += 1
+            charge_time_s += summary["duration_s"]
+
+        session_count = len(sessions)
+        charger_kwh = charger_sum if session_count > 0 else float("nan")
+        # Car energy sums only sessions that had a battery reading, so a rare missing
+        # EnergyRemaining slightly under-counts rather than voiding the whole month.
+        car_kwh = battery_sum if battery_count > 0 else float("nan")
+        wasted_kwh = (
+            charger_kwh - car_kwh
+            if (not math.isnan(charger_kwh) and not math.isnan(car_kwh))
+            else float("nan")
+        )
+        efficiency_pct = (
+            car_kwh / charger_kwh * 100.0
+            if (not math.isnan(car_kwh) and not math.isnan(charger_kwh) and charger_kwh > 0)
+            else float("nan")
+        )
+
+        now_iso = to_flux_time(end_ms)
+        km_month = await self.__month_delta(ODOMETER_ID, now_iso)
+        driving_kwh = await self.__month_delta(DRIVING_ENERGY_ID, now_iso)
+        car_wh_per_km = (
+            driving_kwh * 1000.0 / km_month
+            if (not math.isnan(driving_kwh) and not math.isnan(km_month) and km_month > 0)
+            else float("nan")
+        )
+        charger_wh_per_km = (
+            charger_kwh * 1000.0 / km_month
+            if (not math.isnan(charger_kwh) and not math.isnan(km_month) and km_month > 0)
+            else float("nan")
+        )
+
+        home_grid_kwh = await self.__influx.read_grid_import_kwh_month()
+        if home_grid_kwh is None:
+            home_grid_kwh = float("nan")
+
+        logger.info(
+            "Month charging summary: sessions=%d charger=%s kWh car=%s kWh eff=%s%%",
+            session_count,
+            "n/a" if math.isnan(charger_kwh) else f"{charger_kwh:.2f}",
+            "n/a" if math.isnan(car_kwh) else f"{car_kwh:.2f}",
+            "n/a" if math.isnan(efficiency_pct) else f"{efficiency_pct:.1f}",
+        )
+        return {
+            "charger_kwh": charger_kwh,
+            "car_kwh": car_kwh,
+            "wasted_kwh": wasted_kwh,
+            "efficiency_pct": efficiency_pct,
+            "car_wh_per_km": car_wh_per_km,
+            "charger_wh_per_km": charger_wh_per_km,
+            "driving_kwh": driving_kwh,
+            "km_month": km_month,
+            "session_count": float(session_count),
+            "total_charge_s": charge_time_s,
+            "home_grid_kwh": home_grid_kwh,
+        }
+
+    async def __month_delta(self, data_property_id: str, now_iso: str) -> float:
+        '''
+        Month-to-date delta of a tesla lifetime counter: its last value up to now minus
+        its first value since the 1st of the month (the baseline DrivenThisMonth uses).
+        NaN if either endpoint is missing (InfluxDB down / not logged this month).
+        Arguments:
+            data_property_id (str): The counter's id (Odometer / LifetimeEnergyUsed).
+            now_iso (str): The window end as an RFC3339 string (Flux stop).
+        '''
+        baseline = await self.__influx.read_first_value_month(data_property_id)
+        latest = await self.__influx.read_last_value_before(data_property_id, now_iso)
+        if baseline is None or latest is None:
+            return float("nan")
+        return float(latest) - float(baseline)

--- a/backend/src/charging_service/charging_session.py
+++ b/backend/src/charging_service/charging_session.py
@@ -9,8 +9,11 @@ injected InfluxDBHandler and computes the per-session metrics on demand, caching
 result.
 
 The loss model uses three energy readings over the same window:
-  - charger_kwh  : energy the Zappi delivered this session (myenergi "ChargeAdded",
-                   an accumulator that ramps from 0 — so the in-window MAX is the total)
+  - charger_kwh  : energy the Zappi delivered this session (myenergi "ChargeAdded", an
+                   accumulator — the SUM OF ITS POSITIVE INCREMENTS in the window, which
+                   is robust to the accumulator carrying a value in from charging that
+                   predates the detected session, or resetting mid-window; a plain max
+                   over-counts both)
   - ac_in_kwh    : AC energy the car's onboard charger took in (Tesla
                    "ACChargingEnergyIn", a lifetime counter — so the in-window DELTA)
   - battery_kwh  : energy that actually reached the pack (Tesla "EnergyRemaining"
@@ -26,6 +29,8 @@ partial-data session still yields a well-formed record.
 import logging
 import math
 from datetime import datetime, timezone
+
+import numpy as np
 
 logger = logging.getLogger("charging_service.charging_session")
 
@@ -77,10 +82,17 @@ def _delta(result) -> float:
     return float(values[-1] - values[0])
 
 
-def _max(result) -> float:
-    '''Maximum of a series (an accumulator's in-window peak), or NaN if empty.'''
+def _positive_increment(result) -> float:
+    '''
+    Sum of an accumulator series' positive increments over the read window (kWh) — the
+    energy delivered, robust to the accumulator carrying a non-zero value into the window
+    or resetting inside it (a plain in-window max over-counts both cases). NaN when the
+    series has fewer than two samples (nothing to difference).
+    '''
     values = _series_values(result)
-    return float(values.max()) if values is not None else float("nan")
+    if values is None or len(values) < 2:
+        return float("nan")
+    return float(np.clip(np.diff(values), 0.0, None).sum())
 
 
 def _first(result) -> float:
@@ -158,12 +170,13 @@ class ChargingSession:
 
     async def charger_kwh(self) -> float:
         '''
-        Computes (and caches) just the charger-delivered energy (kWh): the in-window
-        MAX of the myenergi ChargeAdded accumulator (it ramps from 0 to the session
-        total). Split out from summary() so the session-list path — which only needs
-        this for its min-energy filter and the CHARGING_LIST record — can skip the
-        other reads summary() performs. summary() reuses this value. NaN when no
-        charger sample falls in the window.
+        Computes (and caches) just the charger-delivered energy (kWh): the SUM OF POSITIVE
+        INCREMENTS of the myenergi ChargeAdded accumulator over the window (robust to the
+        accumulator carrying a value in from before the detected session, or resetting
+        inside it — a plain max over-counts both). Split out from summary() so the
+        session-list path — which only needs this for its min-energy filter and the
+        CHARGING_LIST record — can skip the other reads summary() performs. summary()
+        reuses this value. NaN when fewer than two charger samples fall in the window.
         '''
         if self.__charger_kwh is not None:
             return self.__charger_kwh
@@ -172,7 +185,7 @@ class ChargingSession:
         charger = await self.__influx.read_charger_data_property(
             CHARGER_ENERGY_ID, start_iso, end_iso
         )
-        self.__charger_kwh = _max(charger)
+        self.__charger_kwh = _positive_increment(charger)
         return self.__charger_kwh
 
     async def summary(self) -> dict:

--- a/backend/src/influxdb_service/influxdb_handler.py
+++ b/backend/src/influxdb_service/influxdb_handler.py
@@ -568,3 +568,53 @@ class InfluxDBHandler:
         value = table.records[0].get_value()
         logger.debug("First value of month for %s: %s", data_property_id, value)
         return value
+
+    async def read_grid_import_kwh_month(self) -> float | None:
+        '''
+        Integrates the logged grid power (myenergi "GridPower", W) over the current
+        calendar month (from the 1st, 00:00 in the configured timezone) into energy (kWh),
+        counting only import (positive power) so grid export does not subtract from
+        "energy bought" — the Charging view's month-to-date home grid-import figure. Uses
+        Flux integral(unit: 1h) (W integrated over hours -> Wh), converted to kWh. Relies
+        on GridPower being logged every poll (MyEnergiService), so the integral has a dense
+        series to trapezoid over. Degrades to None on an unreachable/failed query or a
+        month with no samples yet, matching the other reads' contract.
+        Returns:
+            float | None: Imported energy this month in kWh, or None.
+        '''
+        month_start = datetime.now(self.__timezone).replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
+        ).isoformat()
+
+        # "GridPower" is a fixed literal id (not caller input), so no _SAFE_ID needed.
+        query = f'from(bucket:"{self.__bucket}")'
+        query += f'\n  |> range(start: {month_start})'
+        query += '\n  |> filter(fn: (r) => r["_measurement"] == "myenergi_data")'
+        query += '\n  |> filter(fn: (r) => r["id"] == "GridPower")'
+        query += '\n  |> filter(fn: (r) => r["_field"] == "value_float")'
+        query += '\n  |> keep(columns: ["_time", "_value"])'
+        query += '\n  |> sort(columns: ["_time"])'
+        # Clamp export (negative) to zero so only imported energy is counted, then
+        # integrate W over hours to get Wh.
+        query += '\n  |> map(fn: (r) => ({ r with _value: if r._value < 0.0 then 0.0 else r._value }))'
+        query += '\n  |> integral(unit: 1h)'
+
+        try:
+            result = await self.__client.query_api().query(query=query)
+        except Exception as e:
+            logger.warning(
+                "InfluxDB grid-import-month read failed: %s: %s", type(e).__name__, e
+            )
+            return None
+
+        if len(result) == 0:
+            return None
+
+        table = result[0]
+        if not table.records:
+            return None
+
+        value = table.records[0].get_value()
+        if value is None:
+            return None
+        return float(value) / 1000.0  # Wh -> kWh

--- a/backend/src/influxdb_service/influxdb_handler.py
+++ b/backend/src/influxdb_service/influxdb_handler.py
@@ -592,10 +592,11 @@ class InfluxDBHandler:
         query += '\n  |> filter(fn: (r) => r["_measurement"] == "myenergi_data")'
         query += '\n  |> filter(fn: (r) => r["id"] == "GridPower")'
         query += '\n  |> filter(fn: (r) => r["_field"] == "value_float")'
-        query += '\n  |> keep(columns: ["_time", "_value"])'
         query += '\n  |> sort(columns: ["_time"])'
         # Clamp export (negative) to zero so only imported energy is counted, then
-        # integrate W over hours to get Wh.
+        # integrate W over hours to get Wh. NOTE: integral() requires the range's _start
+        # column to stay in the group key, so we must NOT keep()-drop the columns before
+        # integrating (doing so fails with "integral needs _start column").
         query += '\n  |> map(fn: (r) => ({ r with _value: if r._value < 0.0 then 0.0 else r._value }))'
         query += '\n  |> integral(unit: 1h)'
 

--- a/backend/src/myenergi_service/myenergi_service.py
+++ b/backend/src/myenergi_service/myenergi_service.py
@@ -14,6 +14,7 @@ All myenergi cloud access is through pymyenergi; all InfluxDB access is through 
 injected InfluxDBHandler.
 '''
 import asyncio
+import json
 import logging
 import struct
 from datetime import datetime, timezone
@@ -56,9 +57,11 @@ _MODE_MAP = {
 
 # InfluxDB ids the charger logs under the "myenergi_data" measurement. ChargeAdded is
 # the one the loss calc requires (charging_service reads it back by this exact id);
-# ChargePower is logged for a charger history graph.
+# ChargePower is logged for a charger history graph; GridPower is the household grid
+# exchange logged alongside them.
 _CHARGE_ADDED_ID = "ChargeAdded"
 _CHARGE_POWER_ID = "ChargePower"
+_GRID_POWER_ID = "GridPower"
 
 
 class MyEnergiService:
@@ -186,12 +189,20 @@ class MyEnergiService:
         mode = self.__zappi.charge_mode
         charge_added = self.__zappi.charge_added
         voltage = self.__zappi.supply_voltage
+        grid_power = self.__zappi.power_grid
+        generated_power = self.__zappi.power_generated
+        frequency = self.__zappi.supply_frequency
+        l1_phase = self.__zappi.l1_phase
+        raw = self.__zappi.data
         power = self.__derive_power(charge_added)
 
-        self.__last_frame = self.__build_frame(status, plug, mode, power, charge_added, voltage)
+        self.__last_frame = self.__build_frame(
+            status, plug, mode, power, charge_added, voltage,
+            grid_power, generated_power, frequency, l1_phase, raw,
+        )
         await self.__server.broadcast(self.__last_frame)
 
-        await self.__maybe_log(status, charge_added, power)
+        await self.__log_poll(status, charge_added, power, grid_power)
         self.__adjust_interval(status)
 
     def __derive_power(self, charge_added) -> float:
@@ -215,29 +226,35 @@ class MyEnergiService:
             self.__last_energy = (float(charge_added), now)
         return power
 
-    async def __maybe_log(self, status, charge_added, power) -> None:
+    async def __log_poll(self, status, charge_added, power, grid_power) -> None:
         '''
-        Writes the charger's session energy + derived power to InfluxDB, but only while a
-        session is active (status Charging, or a non-zero accumulator to catch the tail).
-        Logging idle zeros forever would bloat the measurement, and the loss calc only
-        needs samples spanning a charge. A failed write degrades quietly (the handler
-        swallows it) so it never breaks the poll loop.
+        Writes charger telemetry to InfluxDB every poll. GridPower and ChargePower are
+        logged unconditionally so the Charging view's past-hour graphs and the month-to-
+        date home-consumption integral have gap-free data — ChargePower is derived from
+        ΔChargeAdded, so it reads 0 when idle, which is the correct value for the graph.
+        ChargeAdded (the session accumulator) stays gated to an active session (status
+        Charging, or a non-zero accumulator to catch the tail): logging its idle zeros
+        forever would bloat the measurement, and the loss calc only needs samples spanning
+        a charge. A failed write degrades quietly (the handler swallows it) so it never
+        breaks the poll loop.
         Arguments:
             status: The Zappi status string this poll.
             charge_added: Session energy accumulator (kWh) or None.
             power (float): Derived charge power (W).
+            grid_power (float): Net grid power (W); + import / - export.
         '''
-        if charge_added is None:
-            return
-        is_charging = _STATUS_MAP.get(status) == protocol.CHARGER_STATUS_CHARGING
-        if not is_charging and not (charge_added > 0):
-            return
         when = datetime.now(timezone.utc)
         serial = str(getattr(self.__zappi, "serial_number", "") or self.__zappi_serial or "")
+        # GridPower + ChargePower every poll (gap-free for the graphs / home integral).
         points = [
-            self.__point(serial, _CHARGE_ADDED_ID, float(charge_added), when),
-            self.__point(serial, _CHARGE_POWER_ID, float(power), when),
+            self.__point(serial, _GRID_POWER_ID, float(grid_power or 0.0), when),
+            self.__point(serial, _CHARGE_POWER_ID, float(power or 0.0), when),
         ]
+        # ChargeAdded (accumulator) only while a session is active.
+        if charge_added is not None:
+            is_charging = _STATUS_MAP.get(status) == protocol.CHARGER_STATUS_CHARGING
+            if is_charging or charge_added > 0:
+                points.append(self.__point(serial, _CHARGE_ADDED_ID, float(charge_added), when))
         await self.__influx.write_charger_data(points)
 
     def __point(self, serial: str, prop_id: str, value: float, when: datetime) -> Point:
@@ -274,16 +291,27 @@ class MyEnergiService:
             self.__current_interval = desired
             logger.debug("MyEnergi poll interval -> %ds", desired)
 
-    def __build_frame(self, status, plug, mode, power, charge_added, voltage) -> bytes:
+    def __build_frame(
+        self, status, plug, mode, power, charge_added, voltage,
+        grid_power, generated_power, frequency, l1_phase, raw,
+    ) -> bytes:
         '''
         Serialises the Zappi's live state into a CHARGER_STREAM frame: a sequence of
-        (sub_id + value) pairs (the same extensible shape as WEATHER_FORECAST). Missing
-        readings pack as their zero/UNKNOWN code so the frame is always a fixed layout.
+        (sub_id + value) pairs (the same extensible shape as WEATHER_FORECAST). The
+        fixed-width readings pack as their zero/UNKNOWN code when missing so the layout
+        is stable; the final CHARGER_RAW_JSON sub-id carries the complete raw myenergi
+        payload (length-prefixed) so every un-modelled field is still available frontend-
+        side without a protocol change.
         Arguments:
             status / plug / mode: pymyenergi enum strings (mapped to byte codes).
             power (float): Derived charge power (W).
             charge_added: Session energy accumulator (kWh) or None.
             voltage: Supply voltage (V) or None.
+            grid_power: Net grid power (W); + import / - export, or None.
+            generated_power: Local generation power (W), e.g. solar, or None.
+            frequency: Supply frequency (Hz) or None.
+            l1_phase: Which phase L1 is wired to, or None.
+            raw: The full Zappi.data dict for this poll (or None before first refresh).
         '''
         body = bytes()
         body += struct.pack("!B", protocol.CHARGER_STATUS)
@@ -298,4 +326,34 @@ class MyEnergiService:
         body += struct.pack("!d", float(charge_added or 0.0))
         body += struct.pack("!B", protocol.CHARGER_SUPPLY_VOLTAGE)
         body += struct.pack("!H", max(0, min(65535, int(round(voltage or 0)))))
+        body += struct.pack("!B", protocol.CHARGER_GRID_POWER)
+        body += struct.pack("!d", float(grid_power or 0.0))
+        body += struct.pack("!B", protocol.CHARGER_GENERATED_POWER)
+        body += struct.pack("!d", float(generated_power or 0.0))
+        body += struct.pack("!B", protocol.CHARGER_SUPPLY_FREQUENCY)
+        body += struct.pack("!d", float(frequency or 0.0))
+        body += struct.pack("!B", protocol.CHARGER_L1_PHASE)
+        body += struct.pack("!B", max(0, min(255, int(l1_phase or 0))))
+        body += self.__pack_raw(raw)
         return protocol.frame(protocol.CHARGER_STREAM, body)
+
+    def __pack_raw(self, raw) -> bytes:
+        '''
+        Serialises the complete raw pymyenergi Zappi payload (every field the myenergi
+        API returned this poll, most of which the UI never uses) as a length-prefixed
+        UTF-8 JSON blob under the CHARGER_RAW_JSON sub-id. The 4-byte length keeps it
+        self-delimiting, so a client that doesn't care can skip it and new myenergi
+        fields need no protocol change to reach the frontend. Non-serialisable content
+        degrades to an empty object rather than breaking the frame.
+        Arguments:
+            raw: The Zappi.data dict for this poll (or None before the first refresh).
+        '''
+        try:
+            raw_bytes = json.dumps(raw or {}, separators=(",", ":")).encode("utf-8")
+        except (TypeError, ValueError):
+            raw_bytes = b"{}"
+        return (
+            struct.pack("!B", protocol.CHARGER_RAW_JSON)
+            + struct.pack("!I", len(raw_bytes))
+            + raw_bytes
+        )

--- a/backend/src/start_services.py
+++ b/backend/src/start_services.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import math
 import os
 import struct
 from datetime import datetime, timezone
@@ -306,12 +307,65 @@ def _build_charging_summary_frame(
     return protocol.frame(protocol.CHARGING_SUMMARY, body)
 
 
+# The month-to-date charging aggregate fields packed (in order) after the status byte.
+# Every value is an IEEE-754 double; a missing metric packs as NaN, rendered "—".
+# charging_cost_eur is filled by the handler from the configured tariff. Unlike the
+# per-session frames there is no echoed window — the month is derived server-side.
+_CHARGING_MONTH_FIELDS = (
+    "charger_kwh", "car_kwh", "wasted_kwh", "efficiency_pct",
+    "car_wh_per_km", "charger_wh_per_km", "driving_kwh", "km_month",
+    "session_count", "total_charge_s", "charging_cost_eur", "home_grid_kwh",
+)
+
+
+def _build_charging_month_frame(summary: dict | None) -> bytes:
+    '''
+    Builds a CHARGING_MONTH response frame from ChargingLoader.month_summary() plus the
+    handler-computed charging_cost_eur. status is 0 when summary is None (a failed
+    computation), else 1; the fixed field block is always written (NaN-filled on status 0)
+    so the payload is a constant size the client parses without branching. Mirrors
+    _build_charging_summary_frame.
+    Arguments:
+        summary (dict | None): The month aggregate dict, or None.
+    '''
+    status = 0 if summary is None else 1
+    body = struct.pack("!B", status)
+    for field in _CHARGING_MONTH_FIELDS:
+        value = summary.get(field, float("nan")) if summary else float("nan")
+        body += struct.pack("!d", float(value))
+    return protocol.frame(protocol.CHARGING_MONTH, body)
+
+
+def _build_charger_history_frame(data_property_id: str, result) -> bytes:
+    '''
+    Builds a CHARGER_HISTORY response frame — one charger power property's raw time series
+    over the requested window (from read_charger_data_property, "myenergi_data"). The
+    echoed id lets the frontend drop a stale reply; status is 0 (no data) when result is
+    None, else 1. Identical shape to _build_history_frame (TESLA_HISTORY), just a
+    different measurement + message type.
+    Arguments:
+        data_property_id (str): The requested charger property id, echoed back.
+        result: (count, timestamps_ms, values) from get_power_history, or None.
+    '''
+    id_bytes = data_property_id.encode("utf-8")
+    body = struct.pack("!H", len(id_bytes)) + id_bytes
+    if result is None:
+        body += struct.pack("!B", 0) + struct.pack("!I", 0)
+        return protocol.frame(protocol.CHARGER_HISTORY, body)
+    count, timestamps, values = result
+    body += struct.pack("!B", 1) + struct.pack("!I", int(count))
+    for timestamp, value in zip(timestamps, values):
+        body += struct.pack("!q", int(timestamp)) + struct.pack("!d", float(value))
+    return protocol.frame(protocol.CHARGER_HISTORY, body)
+
+
 def _register_handlers(
     server: Server,
     mm: MediaManager,
     vehicle: Vehicle,
     trip_loader: TripLoader,
     charging_loader: ChargingLoader,
+    config: Config,
 ) -> None:
     '''
     Maps every frontend->backend message type to the service method that
@@ -565,6 +619,66 @@ def _register_handlers(
             writer, _build_charging_summary_frame(start_ms, start_ms, end_ms, summary)
         )
 
+    async def _get_charging_month(_payload: bytes, writer) -> None:
+        '''
+        Computes the month-to-date charging aggregate (energy, waste, efficiency,
+        consumption/km, sessions, cost, home import) and replies to the requesting client
+        only. The month runs from the 1st (00:00 in the configured timezone) to now. A
+        failed computation replies status=0 rather than no reply, so the stats grid never
+        hangs. The flat tariff (€/kWh from config, or None) turns charger energy into a
+        cost estimate here, keeping pricing out of the loader.
+        '''
+        summary = None
+        try:
+            now = datetime.now(config.zone_info)
+            month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+            now_ms = int(now.timestamp() * 1000)
+            month_start_ms = int(month_start.timestamp() * 1000)
+            summary = await charging_loader.month_summary(month_start_ms, now_ms)
+            tariff = config.electricity_price_eur_per_kwh
+            charger_kwh = summary.get("charger_kwh", float("nan"))
+            summary["charging_cost_eur"] = (
+                charger_kwh * tariff
+                if (tariff is not None and not math.isnan(charger_kwh))
+                else float("nan")
+            )
+        except Exception as e:
+            logger.warning("CHARGING_GET_MONTH failed: %s: %s", type(e).__name__, e)
+        await server.send_to(writer, _build_charging_month_frame(summary))
+
+    async def _get_charger_history(payload: bytes, writer) -> None:
+        '''
+        Reads a charger (myenergi) power property's raw history for the requested range
+        and replies to the requesting client only — the Charging view's past-hour graphs.
+        Mirrors _get_history but reads the "myenergi_data" measurement (GridPower /
+        ChargePower, logged every poll). A bad id or unreachable InfluxDB replies status=0
+        (no data) rather than no reply, so the graph never hangs.
+        '''
+        if len(payload) < 3:
+            logger.warning("CHARGER_GET_HISTORY: payload too short (%d bytes)", len(payload))
+            return
+        range_code = payload[0]
+        id_len = struct.unpack("!H", payload[1:3])[0]
+        if len(payload) < 3 + id_len + 16:
+            logger.warning(
+                "CHARGER_GET_HISTORY: payload too short for id_len=%d (%d bytes)",
+                id_len, len(payload),
+            )
+            return
+        data_property_id = payload[3:3 + id_len].decode("utf-8")
+        start_ms, end_ms = struct.unpack("!qq", payload[3 + id_len:3 + id_len + 16])
+
+        time_start, time_end = _history_range(range_code, start_ms, end_ms)
+        result = None
+        try:
+            result = await charging_loader.get_power_history(
+                data_property_id, time_start, time_end
+            )
+        except ValueError as e:
+            # Malformed id — reply empty rather than dropping the request.
+            logger.warning("CHARGER_GET_HISTORY rejected: %s", e)
+        await server.send_to(writer, _build_charger_history_frame(data_property_id, result))
+
     # Handlers receive (payload, writer); fire-and-forget commands ignore the
     # writer, request/response handlers (below) reply to it via server.send_to.
     server.register_handler(protocol.MEDIA_SKIP,                 lambda _p, _w: mm.skip_forward())
@@ -583,6 +697,8 @@ def _register_handlers(
     server.register_handler(protocol.TRIP_GET_SERIES,            _get_trip_series)
     server.register_handler(protocol.CHARGING_GET_LIST,          _get_charging_list)
     server.register_handler(protocol.CHARGING_GET_SUMMARY,       _get_charging_summary)
+    server.register_handler(protocol.CHARGING_GET_MONTH,         _get_charging_month)
+    server.register_handler(protocol.CHARGER_GET_HISTORY,        _get_charger_history)
 
 
 async def main():
@@ -661,7 +777,7 @@ async def main():
         )
 
     # Wire incoming-message dispatch and on-connect snapshot before start().
-    _register_handlers(server, mm, vehicle, trip_loader, charging_loader)
+    _register_handlers(server, mm, vehicle, trip_loader, charging_loader, config)
     services = [vehicle, mm, weather]
     if myenergi is not None:
         services.append(myenergi)

--- a/backend/src/start_services.py
+++ b/backend/src/start_services.py
@@ -315,6 +315,7 @@ _CHARGING_MONTH_FIELDS = (
     "charger_kwh", "car_kwh", "wasted_kwh", "efficiency_pct",
     "car_wh_per_km", "charger_wh_per_km", "driving_kwh", "km_month",
     "session_count", "total_charge_s", "charging_cost_eur", "home_grid_kwh",
+    "home_cost_eur",
 )
 
 
@@ -640,6 +641,13 @@ def _register_handlers(
             summary["charging_cost_eur"] = (
                 charger_kwh * tariff
                 if (tariff is not None and not math.isnan(charger_kwh))
+                else float("nan")
+            )
+            # Total home electricity cost this month (all grid import * flat tariff).
+            home_grid_kwh = summary.get("home_grid_kwh", float("nan"))
+            summary["home_cost_eur"] = (
+                home_grid_kwh * tariff
+                if (tariff is not None and not math.isnan(home_grid_kwh))
                 else float("nan")
             )
         except Exception as e:

--- a/backend/src/utils/config_parser.py
+++ b/backend/src/utils/config_parser.py
@@ -186,6 +186,14 @@ class Config:
         return self.__data["spotifyMarket"]
 
     @property
+    def electricity_price_eur_per_kwh(self) -> float | None:
+        '''Flat electricity tariff (EUR/kWh) for the Charging view's cost estimate, or
+        None when not configured (the cost tile then shows "—"). Optional and non-secret;
+        spot/hourly pricing is a separate future feature.'''
+        value = self.get("electricityPriceEurPerKwh")
+        return float(value) if value is not None else None
+
+    @property
     def trip_config(self) -> dict:
         '''Trip-detection tunables (issue #5), with defaults filled in for any
         missing key so a fully or partially absent "trip" block is safe:

--- a/backend/src/utils/logger_configurator.py
+++ b/backend/src/utils/logger_configurator.py
@@ -6,6 +6,11 @@ TESLA_SERVICE = "tesla_service"
 MEDIA_SERVICE = "media_service"
 WEATHER_SERVICE = "weather_service"
 INFLUXDB_SERVICE = "influxdb_service"
+CHARGING_SERVICE = "charging_service"
+MYENERGI_SERVICE = "myenergi_service"
+TRIP_SERVICE = "trip_service"
+SERVER = "server"
+START_SERVICES = "start_services"
 UTILS = "utils"
 
 # ── Format ────────────────────────────────────────────────────────────────────
@@ -18,6 +23,11 @@ _SERVICE_LOGGERS = (
     MEDIA_SERVICE,
     WEATHER_SERVICE,
     INFLUXDB_SERVICE,
+    CHARGING_SERVICE,
+    MYENERGI_SERVICE,
+    TRIP_SERVICE,
+    SERVER,
+    START_SERVICES,
     UTILS,
 )
 

--- a/backend/src/utils/protocol.py
+++ b/backend/src/utils/protocol.py
@@ -148,10 +148,10 @@ CHARGING_SUMMARY = 0x83      # B->F: session_id(8B) + status(1B) + start_ms(8B) 
 # 1st (00:00 in the configured timezone) to now, sums the myenergi-detected sessions and
 # reads the tesla month counters, so the request carries no window.
 CHARGING_GET_MONTH = 0x84  # F->B: (empty)
-CHARGING_MONTH = 0x85      # B->F: status(1B) + 12*double(8B): charger_kwh, car_kwh,
+CHARGING_MONTH = 0x85      # B->F: status(1B) + 13*double(8B): charger_kwh, car_kwh,
                            #       wasted_kwh, efficiency_pct, car_wh_per_km, charger_wh_per_km,
                            #       driving_kwh, km_month, session_count, total_charge_s,
-                           #       charging_cost_eur, home_grid_kwh (any may be NaN)
+                           #       charging_cost_eur, home_grid_kwh, home_cost_eur (any may be NaN)
 
 # Charger (myenergi) telemetry history — the Charging view's past-hour power graphs.
 # Request/response, replied to the requesting client only. Same shape as TESLA_HISTORY,

--- a/backend/src/utils/protocol.py
+++ b/backend/src/utils/protocol.py
@@ -84,10 +84,11 @@ TRIP_SERIES = 0x7D       # B->F: trip_id(8B) + id(len(2B)+UTF-8) + status(1B) + 
 
 # MyEnergi (Zappi) charger live stream (backend -> frontend). Like the weather
 # frame, a CHARGER_STREAM packet is a sequence of (sub_id(1B) + value) pairs; each
-# sub_id implies its value width, so fields can be added without a format bump, and
-# a field absent from a given frame just keeps its last value on the frontend. The
-# service polls the myenergi cloud (pymyenergi) and broadcasts this; a new client
-# gets the last frame replayed via stream_everything.
+# fixed-width sub_id implies its value width, so fields can be added without a format
+# bump, and a field absent from a given frame just keeps its last value on the
+# frontend. The one variable-width sub_id, CHARGER_RAW_JSON, is length-prefixed (4B)
+# so it stays self-delimiting. The service polls the myenergi cloud (pymyenergi) and
+# broadcasts this; a new client gets the last frame replayed via stream_everything.
 CHARGER_STREAM = 0x50
 CHARGER_STATUS = 0x51           # uint8: see CHARGER_STATUS_* below
 CHARGER_PLUG_STATUS = 0x52      # uint8: see CHARGER_PLUG_* below
@@ -95,6 +96,14 @@ CHARGER_MODE = 0x53             # uint8: see CHARGER_MODE_* below
 CHARGER_CHARGE_POWER = 0x54     # float64: power currently delivered to the car (W)
 CHARGER_SESSION_ENERGY = 0x55   # float64: energy added this charging session (kWh)
 CHARGER_SUPPLY_VOLTAGE = 0x56   # uint16: supply voltage (V)
+CHARGER_GRID_POWER = 0x57       # float64: net grid power (W); + import from grid / - export
+CHARGER_GENERATED_POWER = 0x58  # float64: local generation power (W), e.g. solar / PV
+CHARGER_SUPPLY_FREQUENCY = 0x59 # float64: supply frequency (Hz)
+CHARGER_L1_PHASE = 0x5A         # uint8: which phase L1 is wired to (pymyenergi Zappi.l1_phase)
+CHARGER_RAW_JSON = 0x5F         # length(4B) + UTF-8 JSON: the complete raw pymyenergi
+                                #   Zappi.data payload — every field the myenergi API
+                                #   returned this poll (most never used). Lets new fields
+                                #   reach the frontend with no protocol change.
 
 # CHARGER_STATUS enum (maps pymyenergi Zappi.status: Paused/Charging/Completed)
 CHARGER_STATUS_UNKNOWN = 0
@@ -133,6 +142,23 @@ CHARGING_SUMMARY = 0x83      # B->F: session_id(8B) + status(1B) + start_ms(8B) 
                              #       + 9*double(8B): charger_kwh, ac_in_kwh, battery_kwh,
                              #       loss_cable_kwh, loss_conversion_kwh, loss_total_kwh,
                              #       loss_total_pct, start_soc, end_soc (any may be NaN)
+
+# Month-to-date charging aggregate (the Charging view's stats grid). Request/response,
+# replied to the requesting client only. The backend derives the month window from the
+# 1st (00:00 in the configured timezone) to now, sums the myenergi-detected sessions and
+# reads the tesla month counters, so the request carries no window.
+CHARGING_GET_MONTH = 0x84  # F->B: (empty)
+CHARGING_MONTH = 0x85      # B->F: status(1B) + 12*double(8B): charger_kwh, car_kwh,
+                           #       wasted_kwh, efficiency_pct, car_wh_per_km, charger_wh_per_km,
+                           #       driving_kwh, km_month, session_count, total_charge_s,
+                           #       charging_cost_eur, home_grid_kwh (any may be NaN)
+
+# Charger (myenergi) telemetry history — the Charging view's past-hour power graphs.
+# Request/response, replied to the requesting client only. Same shape as TESLA_HISTORY,
+# but read from the "myenergi_data" measurement (GridPower / ChargePower), which is now
+# logged every poll so the series is gap-free.
+CHARGER_GET_HISTORY = 0x86  # F->B: range_code(1B) + id(len(2B)+UTF-8) + start_ms(8B) + end_ms(8B)
+CHARGER_HISTORY = 0x87      # B->F: id(len(2B)+UTF-8) + status(1B) + count(4B) + count*(ts_ms(8B)+value(8B double))
 
 # Maximum accepted size of a single incoming message (defensive cap)
 MAX_MSG_SIZE = 1024 * 1024  # 1 MB

--- a/config_template.json
+++ b/config_template.json
@@ -385,6 +385,7 @@
     "spotifyRedirectUri": "http://127.0.0.1:8080/callback",
     "timeZone": "Europe/Helsinki",
     "spotifyMarket": "FI",
+    "electricityPriceEurPerKwh": null,
     "myenergi": {
         "zappiSerial": "",
         "pollIntervalIdleSeconds": 30,

--- a/frontend_v2/CMakeLists.txt
+++ b/frontend_v2/CMakeLists.txt
@@ -21,6 +21,25 @@ set(CMAKE_AUTOMOC ON)
 # code); make MSVC read sources as UTF-8 rather than the system code page.
 add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/utf-8>)
 
+# --- Compiler cache (sccache / ccache) -------------------------------------
+# Reuse compiled objects across builds AND across git worktrees, so a fresh
+# worktree's "clean" rebuild is mostly cache hits. Auto-enabled when sccache or
+# ccache is on PATH; a plain no-op otherwise. On MSVC the cache can only reuse an
+# object when its debug info is embedded (/Z7) rather than written to a shared
+# .pdb (/Zi), so rewrite the default debug flags accordingly.
+find_program(COMPILER_CACHE NAMES sccache ccache)
+if(COMPILER_CACHE)
+    set(CMAKE_CXX_COMPILER_LAUNCHER "${COMPILER_CACHE}")
+    set(CMAKE_C_COMPILER_LAUNCHER "${COMPILER_CACHE}")
+    if(MSVC)
+        foreach(cfg DEBUG RELWITHDEBINFO)
+            string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_${cfg} "${CMAKE_CXX_FLAGS_${cfg}}")
+            string(REPLACE "/ZI" "/Z7" CMAKE_CXX_FLAGS_${cfg} "${CMAKE_CXX_FLAGS_${cfg}}")
+        endforeach()
+    endif()
+    message(STATUS "Compiler cache enabled: ${COMPILER_CACHE}")
+endif()
+
 qt_add_executable(appfrontend_v2
     main.cpp
     core/protocol.hh
@@ -38,6 +57,8 @@ qt_add_executable(appfrontend_v2
     core/tesla/teslahistory.cpp
     core/trip/tripsdata.hh
     core/trip/tripsdata.cpp
+    core/charging/chargingdata.hh
+    core/charging/chargingdata.cpp
     core/media/mediaimagecache.hh
     core/media/mediaimageprovider.hh
     core/media/mediadata.hh
@@ -66,6 +87,7 @@ qt_add_qml_module(appfrontend_v2
         views/MediaView.qml
         views/MapView.qml
         views/TripsView.qml
+        views/ChargingView.qml
         items/trip/TripMap.qml
         items/trip/TripComboBox.qml
         items/trip/WeekSelector.qml
@@ -75,6 +97,9 @@ qt_add_qml_module(appfrontend_v2
         items/trip/TripStatsGrid.qml
         items/trip/TripPropertySelector.qml
         items/trip/TripGraphCard.qml
+        items/charging/ChargingGraphCard.qml
+        items/charging/ChargingStatsGrid.qml
+        items/charging/ChargingLiveCard.qml
         items/history/PropertySelector.qml
         items/history/RangeSelector.qml
         items/history/DateTimePicker.qml

--- a/frontend_v2/CMakeLists.txt
+++ b/frontend_v2/CMakeLists.txt
@@ -170,6 +170,7 @@ qt_add_resources(appfrontend_v2 "app_resources"
         resources/icons/arrow.svg
         resources/icons/arrow_left.svg
         resources/icons/arrow_right.svg
+        resources/icons/charger.svg
         resources/icons/chart_line.svg
         resources/icons/cooling.png
         resources/icons/greenshadow.png

--- a/frontend_v2/Main.qml
+++ b/frontend_v2/Main.qml
@@ -26,7 +26,8 @@ Window {
         { name: qsTr("Kartta"), icon: "qrc:/resources/icons/location.svg", component: mapComponent },
         { name: qsTr("Musiikki"), icon: "qrc:/resources/icons/music.svg", component: mediaComponent },
         { name: qsTr("Historia"), icon: "qrc:/resources/icons/chart_line.svg", component: historyComponent },
-        { name: qsTr("Matkat"), icon: "qrc:/resources/icons/trip.svg", component: tripsComponent }
+        { name: qsTr("Matkat"), icon: "qrc:/resources/icons/trip.svg", component: tripsComponent },
+        { name: qsTr("Lataus"), icon: "qrc:/resources/icons/power_on.svg", component: chargingComponent }
     ]
     property int currentView: 0
 
@@ -35,6 +36,7 @@ Window {
     Component { id: mediaComponent; MediaView {} }
     Component { id: historyComponent; HistoryView {} }
     Component { id: tripsComponent; TripsView {} }
+    Component { id: chargingComponent; ChargingView {} }
 
     // --- Dock reveal state ------------------------------------------------
     // 0.0 = dock fully hidden (off-screen), 1.0 = dock fully shown.

--- a/frontend_v2/Main.qml
+++ b/frontend_v2/Main.qml
@@ -27,7 +27,7 @@ Window {
         { name: qsTr("Musiikki"), icon: "qrc:/resources/icons/music.svg", component: mediaComponent },
         { name: qsTr("Historia"), icon: "qrc:/resources/icons/chart_line.svg", component: historyComponent },
         { name: qsTr("Matkat"), icon: "qrc:/resources/icons/trip.svg", component: tripsComponent },
-        { name: qsTr("Lataus"), icon: "qrc:/resources/icons/power_on.svg", component: chargingComponent }
+        { name: qsTr("Lataus"), icon: "qrc:/resources/icons/charger.svg", component: chargingComponent }
     ]
     property int currentView: 0
 

--- a/frontend_v2/core/charging/chargingdata.cpp
+++ b/frontend_v2/core/charging/chargingdata.cpp
@@ -137,8 +137,8 @@ void ChargingData::parseMonth(const QByteArray &payload) {
     stream.setByteOrder(QDataStream::BigEndian);
     QIODevice *device = stream.device();
 
-    // status(1) + 12*double(8) = 97 bytes.
-    if (device->bytesAvailable() < 97) {
+    // status(1) + 13*double(8) = 105 bytes.
+    if (device->bytesAvailable() < 105) {
         logger.warning(QStringLiteral("Charging-month frame too short"));
         setMonthLoading(false);
         return;
@@ -157,9 +157,10 @@ void ChargingData::parseMonth(const QByteArray &payload) {
     double totalChargeS;
     double chargingCostEur;
     double homeGridKwh;
+    double homeCostEur;
     stream >> chargerKwh >> carKwh >> wastedKwh >> efficiencyPct >> carWhPerKm
            >> chargerWhPerKm >> drivingKwh >> kmMonth >> sessionCount >> totalChargeS
-           >> chargingCostEur >> homeGridKwh;
+           >> chargingCostEur >> homeGridKwh >> homeCostEur;
 
     QVariantMap month;
     month.insert(QStringLiteral("valid"), status == 1);
@@ -175,6 +176,7 @@ void ChargingData::parseMonth(const QByteArray &payload) {
     month.insert(QStringLiteral("totalChargeS"), totalChargeS);
     month.insert(QStringLiteral("chargingCostEur"), chargingCostEur);
     month.insert(QStringLiteral("homeGridKwh"), homeGridKwh);
+    month.insert(QStringLiteral("homeCostEur"), homeCostEur);
 
     m_month = month;
     m_monthRequested = false;

--- a/frontend_v2/core/charging/chargingdata.cpp
+++ b/frontend_v2/core/charging/chargingdata.cpp
@@ -1,0 +1,371 @@
+#include "chargingdata.hh"
+
+#include "../logger.hh"
+#include "../protocol.hh"
+#include "../serverclient.hh"
+
+#include <QDataStream>
+#include <QDateTime>
+#include <QIODevice>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QPointF>
+#include <QString>
+#include <limits>
+
+namespace {
+const Logger logger = Logger::get("charging");
+}
+
+ChargingData::ChargingData(ServerClient *server, QObject *parent)
+    : QObject(parent), m_server(server) {
+    connect(server, &ServerClient::packetReceived, this, &ChargingData::onPacket);
+    // Self-heal: a request written into a disconnected socket is silently dropped, so
+    // re-issue any still-pending request when the connection is (re)established.
+    connect(server, &ServerClient::connectedChanged, this, &ChargingData::onConnectedChanged);
+}
+
+void ChargingData::onPacket(quint8 type, const QByteArray &payload) {
+    switch (type) {
+        case protocol::CHARGER_STREAM:
+            parseStream(payload);
+            break;
+        case protocol::CHARGING_MONTH:
+            parseMonth(payload);
+            break;
+        case protocol::CHARGER_HISTORY:
+            parseChargerHistory(payload);
+            break;
+        default:
+            break;  // not ours
+    }
+}
+
+void ChargingData::parseStream(const QByteArray &payload) {
+    QDataStream stream(payload);
+    stream.setByteOrder(QDataStream::BigEndian);
+    QIODevice *device = stream.device();
+
+    // A sequence of (sub_id + value) pairs. Unlike the weather frame these values are
+    // NOT all one byte wide, so an UNKNOWN sub-id can't be skipped safely (its width is
+    // unknown) — stop parsing at one instead of desyncing. All current sub-ids are known
+    // and CHARGER_RAW_JSON is last, so version skew only drops trailing new fields.
+    while (device->bytesAvailable() >= 1) {
+        quint8 subId;
+        stream >> subId;
+        bool stop = false;
+        switch (subId) {
+            case protocol::CHARGER_STATUS:
+                if (device->bytesAvailable() < 1) { stop = true; break; }
+                { quint8 v; stream >> v; m_status = v; }
+                break;
+            case protocol::CHARGER_PLUG_STATUS:
+                if (device->bytesAvailable() < 1) { stop = true; break; }
+                { quint8 v; stream >> v; m_plugStatus = v; }
+                break;
+            case protocol::CHARGER_MODE:
+                if (device->bytesAvailable() < 1) { stop = true; break; }
+                { quint8 v; stream >> v; m_mode = v; }
+                break;
+            case protocol::CHARGER_L1_PHASE:
+                if (device->bytesAvailable() < 1) { stop = true; break; }
+                { quint8 v; stream >> v; m_l1Phase = v; }
+                break;
+            case protocol::CHARGER_SUPPLY_VOLTAGE:
+                if (device->bytesAvailable() < 2) { stop = true; break; }
+                { quint16 v; stream >> v; m_supplyVoltage = v; }
+                break;
+            case protocol::CHARGER_CHARGE_POWER:
+                if (device->bytesAvailable() < 8) { stop = true; break; }
+                { double v; stream >> v; m_chargePowerW = v; }
+                break;
+            case protocol::CHARGER_SESSION_ENERGY:
+                if (device->bytesAvailable() < 8) { stop = true; break; }
+                { double v; stream >> v; m_sessionEnergyKwh = v; }
+                break;
+            case protocol::CHARGER_GRID_POWER:
+                if (device->bytesAvailable() < 8) { stop = true; break; }
+                { double v; stream >> v; m_gridPowerW = v; }
+                break;
+            case protocol::CHARGER_GENERATED_POWER:
+                if (device->bytesAvailable() < 8) { stop = true; break; }
+                { double v; stream >> v; m_generatedPowerW = v; }
+                break;
+            case protocol::CHARGER_SUPPLY_FREQUENCY:
+                if (device->bytesAvailable() < 8) { stop = true; break; }
+                { double v; stream >> v; m_supplyFrequency = v; }
+                break;
+            case protocol::CHARGER_RAW_JSON: {
+                if (device->bytesAvailable() < 4) { stop = true; break; }
+                quint32 len;
+                stream >> len;
+                if (static_cast<quint32>(device->bytesAvailable()) < len) { stop = true; break; }
+                QByteArray rawBytes(static_cast<int>(len), Qt::Uninitialized);
+                stream.readRawData(rawBytes.data(), static_cast<int>(len));
+                const QJsonDocument doc = QJsonDocument::fromJson(rawBytes);
+                if (doc.isObject()) {
+                    m_raw = doc.object().toVariantMap();
+                }
+                break;
+            }
+            default:
+                stop = true;  // unknown width — cannot skip, stop the frame
+                break;
+        }
+        if (stop) {
+            break;
+        }
+    }
+
+    m_hasLiveState = true;
+    emit liveStateChanged();
+
+    // Extend the rolling power graphs from this frame while the view is live.
+    if (m_graphLive) {
+        const qint64 now = QDateTime::currentMSecsSinceEpoch();
+        appendLive(m_grid, m_gridPowerW, now);
+        emit gridChanged();
+        emit gridTick();
+        appendLive(m_charge, m_chargePowerW, now);
+        emit chargeChanged();
+        emit chargeTick();
+    }
+}
+
+void ChargingData::parseMonth(const QByteArray &payload) {
+    QDataStream stream(payload);
+    stream.setByteOrder(QDataStream::BigEndian);
+    QIODevice *device = stream.device();
+
+    // status(1) + 12*double(8) = 97 bytes.
+    if (device->bytesAvailable() < 97) {
+        logger.warning(QStringLiteral("Charging-month frame too short"));
+        setMonthLoading(false);
+        return;
+    }
+    quint8 status;
+    stream >> status;
+    double chargerKwh;
+    double carKwh;
+    double wastedKwh;
+    double efficiencyPct;
+    double carWhPerKm;
+    double chargerWhPerKm;
+    double drivingKwh;
+    double kmMonth;
+    double sessionCount;
+    double totalChargeS;
+    double chargingCostEur;
+    double homeGridKwh;
+    stream >> chargerKwh >> carKwh >> wastedKwh >> efficiencyPct >> carWhPerKm
+           >> chargerWhPerKm >> drivingKwh >> kmMonth >> sessionCount >> totalChargeS
+           >> chargingCostEur >> homeGridKwh;
+
+    QVariantMap month;
+    month.insert(QStringLiteral("valid"), status == 1);
+    month.insert(QStringLiteral("chargerKwh"), chargerKwh);
+    month.insert(QStringLiteral("carKwh"), carKwh);
+    month.insert(QStringLiteral("wastedKwh"), wastedKwh);
+    month.insert(QStringLiteral("efficiencyPct"), efficiencyPct);
+    month.insert(QStringLiteral("carWhPerKm"), carWhPerKm);
+    month.insert(QStringLiteral("chargerWhPerKm"), chargerWhPerKm);
+    month.insert(QStringLiteral("drivingKwh"), drivingKwh);
+    month.insert(QStringLiteral("kmMonth"), kmMonth);
+    month.insert(QStringLiteral("sessionCount"), sessionCount);
+    month.insert(QStringLiteral("totalChargeS"), totalChargeS);
+    month.insert(QStringLiteral("chargingCostEur"), chargingCostEur);
+    month.insert(QStringLiteral("homeGridKwh"), homeGridKwh);
+
+    m_month = month;
+    m_monthRequested = false;
+    setMonthLoading(false);
+    emit monthChanged();
+    emit monthReady();
+    logger.debug(QStringLiteral("Charging-month applied | status=%1").arg(status));
+}
+
+void ChargingData::parseChargerHistory(const QByteArray &payload) {
+    QDataStream stream(payload);
+    stream.setByteOrder(QDataStream::BigEndian);
+    QIODevice *device = stream.device();
+
+    if (device->bytesAvailable() < 2) {
+        logger.warning(QStringLiteral("Charger-history frame too short (id)"));
+        return;
+    }
+    quint16 idLen;
+    stream >> idLen;
+    if (device->bytesAvailable() < idLen) {
+        logger.warning(QStringLiteral("Charger-history frame too short (id body)"));
+        return;
+    }
+    QByteArray idBytes(idLen, '\0');
+    stream.readRawData(idBytes.data(), idLen);
+    const QString id = QString::fromUtf8(idBytes);
+
+    if (device->bytesAvailable() < 5) {
+        logger.warning(QStringLiteral("Charger-history frame too short (header)"));
+        return;
+    }
+    quint8 status;
+    stream >> status;
+    quint32 count;
+    stream >> count;
+
+    QVariantList points;
+    if (status == 1) {
+        points.reserve(static_cast<int>(count));
+        for (quint32 i = 0; i < count; ++i) {
+            if (device->bytesAvailable() < 16) {
+                logger.warning(QStringLiteral("Truncated charger-history points at %1").arg(i));
+                break;
+            }
+            qint64 ts;
+            double value;
+            stream >> ts >> value;
+            points.append(QVariant::fromValue(QPointF(static_cast<double>(ts), value)));
+        }
+    }
+
+    const qint64 now = QDateTime::currentMSecsSinceEpoch();
+    if (id == QStringLiteral("GridPower")) {
+        seedSeries(m_grid, points, now);
+        emit gridChanged();
+        emit gridReady();
+    } else if (id == QStringLiteral("ChargePower")) {
+        seedSeries(m_charge, points, now);
+        emit chargeChanged();
+        emit chargeReady();
+    } else {
+        return;  // a series this view doesn't graph
+    }
+    // Both series are requested together; clear the indicator once either lands.
+    setHistoryLoading(false);
+    logger.debug(QStringLiteral("Charger history applied | id=%1 points=%2 status=%3")
+                     .arg(id)
+                     .arg(points.size())
+                     .arg(status));
+}
+
+void ChargingData::seedSeries(Series &s, const QVariantList &points, qint64 nowMs) {
+    s.points = points;
+    // Show the whole 1 h window on the axis (not just the seeded data extent), matching
+    // TeslaHistory's live seed; live appends then roll it forward.
+    rollBounds(s, nowMs);
+}
+
+void ChargingData::appendLive(Series &s, double value, qint64 nowMs) {
+    // Store a real point only when the value changed since the last sample; between
+    // changes the step line holds the previous value flat to the advancing right edge.
+    const bool changed =
+        s.points.isEmpty() || s.points.last().toPointF().y() != value;
+    if (changed) {
+        s.points.append(QVariant::fromValue(QPointF(static_cast<double>(nowMs), value)));
+    }
+    rollBounds(s, nowMs);
+}
+
+void ChargingData::rollBounds(Series &s, qint64 nowMs) {
+    const double left = static_cast<double>(nowMs - kWindowMs);
+    // Drop points older than the left edge, but keep the last one before it as the
+    // boundary so the value held at the edge is still known (the step line needs it).
+    int firstInside = 0;
+    while (firstInside < s.points.size() && s.points[firstInside].toPointF().x() < left) {
+        ++firstInside;
+    }
+    const int dropCount = firstInside > 0 ? firstInside - 1 : 0;
+    if (dropCount > 0) {
+        s.points.remove(0, dropCount);
+    }
+    s.minX = left;
+    s.maxX = static_cast<double>(nowMs);
+    double minY = std::numeric_limits<double>::max();
+    double maxY = std::numeric_limits<double>::lowest();
+    for (const QVariant &p : s.points) {
+        const double y = p.toPointF().y();
+        minY = qMin(minY, y);
+        maxY = qMax(maxY, y);
+    }
+    if (s.points.isEmpty()) {
+        s.minY = 0.0;
+        s.maxY = 1.0;
+    } else {
+        s.minY = minY;
+        s.maxY = maxY;
+    }
+}
+
+QVariantMap ChargingData::seriesMap(const Series &s) {
+    QVariantMap m;
+    m.insert(QStringLiteral("points"), s.points);
+    m.insert(QStringLiteral("minX"), s.minX);
+    m.insert(QStringLiteral("maxX"), s.maxX);
+    m.insert(QStringLiteral("minY"), s.minY);
+    m.insert(QStringLiteral("maxY"), s.maxY);
+    m.insert(QStringLiteral("count"), static_cast<int>(s.points.size()));
+    return m;
+}
+
+void ChargingData::sendHistoryRequest(const QString &id) {
+    QByteArray payload;
+    QDataStream stream(&payload, QIODevice::WriteOnly);
+    stream.setByteOrder(QDataStream::BigEndian);
+    stream << static_cast<quint8>(protocol::HISTORY_RANGE_1H);
+    const QByteArray idBytes = id.toUtf8();
+    stream << static_cast<quint16>(idBytes.size());
+    stream.writeRawData(idBytes.constData(), static_cast<int>(idBytes.size()));
+    // Preset range ignores the bounds; send zeros to keep the fixed wire layout.
+    stream << static_cast<qint64>(0) << static_cast<qint64>(0);
+    m_server->sendPacket(protocol::frame(protocol::CHARGER_GET_HISTORY, payload));
+}
+
+void ChargingData::startLive() {
+    m_graphLive = true;
+    setHistoryLoading(true);
+    sendHistoryRequest(QStringLiteral("GridPower"));
+    sendHistoryRequest(QStringLiteral("ChargePower"));
+    logger.info(QStringLiteral("Charger power history requested (grid + charge)"));
+}
+
+void ChargingData::stopLive() {
+    m_graphLive = false;
+}
+
+void ChargingData::requestMonth() {
+    m_monthRequested = true;
+    setMonthLoading(true);
+    m_server->sendPacket(protocol::frame(protocol::CHARGING_GET_MONTH));
+    logger.info(QStringLiteral("Month charging summary requested"));
+}
+
+void ChargingData::onConnectedChanged() {
+    if (!m_server->connected()) {
+        return;
+    }
+    if (m_graphLive) {
+        logger.info(QStringLiteral("Reconnected — re-requesting charger power history"));
+        setHistoryLoading(true);
+        sendHistoryRequest(QStringLiteral("GridPower"));
+        sendHistoryRequest(QStringLiteral("ChargePower"));
+    }
+    if (m_monthRequested) {
+        logger.info(QStringLiteral("Reconnected — re-requesting month charging summary"));
+        m_server->sendPacket(protocol::frame(protocol::CHARGING_GET_MONTH));
+    }
+}
+
+void ChargingData::setMonthLoading(bool loading) {
+    if (m_monthLoading == loading) {
+        return;
+    }
+    m_monthLoading = loading;
+    emit monthLoadingChanged();
+}
+
+void ChargingData::setHistoryLoading(bool loading) {
+    if (m_historyLoading == loading) {
+        return;
+    }
+    m_historyLoading = loading;
+    emit historyLoadingChanged();
+}

--- a/frontend_v2/core/charging/chargingdata.hh
+++ b/frontend_v2/core/charging/chargingdata.hh
@@ -1,0 +1,156 @@
+#ifndef FRONTEND_V2_CHARGINGDATA_HH
+#define FRONTEND_V2_CHARGINGDATA_HH
+
+#include <QByteArray>
+#include <QObject>
+#include <QVariantList>
+#include <QVariantMap>
+
+class ServerClient;
+
+/**
+ * ChargingData — the Charging-view datahandler, exposed to QML as the `Charging`
+ * singleton. It combines three flows over the one socket:
+ *
+ *  - Live charger state: parses the CHARGER_STREAM broadcast (myenergi) into the scalar
+ *    tile properties (status/plug/mode/powers/energy/voltage/frequency/phase) plus the
+ *    full raw Zappi payload (`raw`). Updated on every frame regardless of view state.
+ *  - Past-hour power graphs: startLive() seeds two rolling 1 h series (grid power +
+ *    charge power) from CHARGER_HISTORY, then extends each from the live stream — every
+ *    series drives a HistoryGraph via a ready (reload) + tick (advance) signal, the same
+ *    contract TeslaHistory's live mode uses, but sourced from the stream instead of a
+ *    polled value. stopLive() freezes the graph buffers while the view is hidden.
+ *  - Month-to-date stats: requestMonth() -> CHARGING_MONTH -> the `monthSummary` map.
+ *
+ * Parsing runs on the GUI thread (the bound properties are not thread-safe); malformed/
+ * truncated frames are dropped. A charger-history reply is routed to its series by the
+ * echoed id; a request dropped while the socket was down is re-issued on reconnect
+ * (mirroring TripsData / TeslaHistory).
+ */
+class ChargingData : public QObject {
+    Q_OBJECT
+    // Live charger state (CHARGER_STREAM).
+    Q_PROPERTY(bool hasLiveState READ hasLiveState NOTIFY liveStateChanged)
+    Q_PROPERTY(int status READ status NOTIFY liveStateChanged)
+    Q_PROPERTY(int plugStatus READ plugStatus NOTIFY liveStateChanged)
+    Q_PROPERTY(int mode READ mode NOTIFY liveStateChanged)
+    Q_PROPERTY(double chargePowerW READ chargePowerW NOTIFY liveStateChanged)
+    Q_PROPERTY(double gridPowerW READ gridPowerW NOTIFY liveStateChanged)
+    Q_PROPERTY(double generatedPowerW READ generatedPowerW NOTIFY liveStateChanged)
+    Q_PROPERTY(double sessionEnergyKwh READ sessionEnergyKwh NOTIFY liveStateChanged)
+    Q_PROPERTY(double supplyVoltage READ supplyVoltage NOTIFY liveStateChanged)
+    Q_PROPERTY(double supplyFrequency READ supplyFrequency NOTIFY liveStateChanged)
+    Q_PROPERTY(int l1Phase READ l1Phase NOTIFY liveStateChanged)
+    Q_PROPERTY(QVariantMap raw READ raw NOTIFY liveStateChanged)
+
+    // Month-to-date aggregate (CHARGING_MONTH): `valid` + the 12 fields (NaN -> "—").
+    Q_PROPERTY(QVariantMap monthSummary READ monthSummary NOTIFY monthChanged)
+    Q_PROPERTY(bool monthLoading READ monthLoading NOTIFY monthLoadingChanged)
+
+    // Past-hour power series, each { points: [{x,y}], minX, maxX, minY, maxY, count }.
+    Q_PROPERTY(QVariantMap gridSeries READ gridSeries NOTIFY gridChanged)
+    Q_PROPERTY(QVariantMap chargeSeries READ chargeSeries NOTIFY chargeChanged)
+    Q_PROPERTY(bool historyLoading READ historyLoading NOTIFY historyLoadingChanged)
+
+public:
+    explicit ChargingData(ServerClient *server, QObject *parent = nullptr);
+
+    bool hasLiveState() const { return m_hasLiveState; }
+    int status() const { return m_status; }
+    int plugStatus() const { return m_plugStatus; }
+    int mode() const { return m_mode; }
+    double chargePowerW() const { return m_chargePowerW; }
+    double gridPowerW() const { return m_gridPowerW; }
+    double generatedPowerW() const { return m_generatedPowerW; }
+    double sessionEnergyKwh() const { return m_sessionEnergyKwh; }
+    double supplyVoltage() const { return m_supplyVoltage; }
+    double supplyFrequency() const { return m_supplyFrequency; }
+    int l1Phase() const { return m_l1Phase; }
+    QVariantMap raw() const { return m_raw; }
+    QVariantMap monthSummary() const { return m_month; }
+    bool monthLoading() const { return m_monthLoading; }
+    QVariantMap gridSeries() const { return seriesMap(m_grid); }
+    QVariantMap chargeSeries() const { return seriesMap(m_charge); }
+    bool historyLoading() const { return m_historyLoading; }
+
+    // Begin/refresh the live past-hour graphs: seed both series from history and let the
+    // live stream extend them. Call when the view becomes current.
+    Q_INVOKABLE void startLive();
+    // Stop extending the graphs from the stream (the view is hidden). Live tile state
+    // keeps updating; only the graph buffers freeze.
+    Q_INVOKABLE void stopLive();
+    // Ask the backend for the month-to-date aggregate (the stats grid).
+    Q_INVOKABLE void requestMonth();
+
+signals:
+    void liveStateChanged();
+    void monthChanged();
+    void monthReady();
+    void monthLoadingChanged();
+    void gridChanged();
+    void gridReady();  // fresh grid seed -> HistoryGraph.reloadFull()
+    void gridTick();   // live grid append -> HistoryGraph.advanceLive()
+    void chargeChanged();
+    void chargeReady();
+    void chargeTick();
+    void historyLoadingChanged();
+
+private slots:
+    void onPacket(quint8 type, const QByteArray &payload);
+    // Re-issue a request dropped while the socket was down (sendPacket is a non-blocking
+    // write that no-ops when disconnected). Fires on the connection state changing.
+    void onConnectedChanged();
+
+private:
+    // One rolling past-hour series. points is a QPointF list ascending by x (epoch ms),
+    // fed straight into a HistoryGraph.
+    struct Series {
+        QVariantList points;
+        double minX = 0.0;
+        double maxX = 1.0;
+        double minY = 0.0;
+        double maxY = 1.0;
+    };
+
+    void parseStream(const QByteArray &payload);
+    void parseMonth(const QByteArray &payload);
+    void parseChargerHistory(const QByteArray &payload);
+    void sendHistoryRequest(const QString &id);
+    void seedSeries(Series &s, const QVariantList &points, qint64 nowMs);
+    void appendLive(Series &s, double value, qint64 nowMs);
+    void rollBounds(Series &s, qint64 nowMs);
+    static QVariantMap seriesMap(const Series &s);
+    void setMonthLoading(bool loading);
+    void setHistoryLoading(bool loading);
+
+    ServerClient *m_server;
+
+    // Live charger state.
+    bool m_hasLiveState = false;
+    int m_status = 0;
+    int m_plugStatus = 0;
+    int m_mode = 0;
+    double m_chargePowerW = 0.0;
+    double m_gridPowerW = 0.0;
+    double m_generatedPowerW = 0.0;
+    double m_sessionEnergyKwh = 0.0;
+    double m_supplyVoltage = 0.0;
+    double m_supplyFrequency = 0.0;
+    int m_l1Phase = 0;
+    QVariantMap m_raw;
+
+    // Month aggregate + reconnect-retry flag.
+    QVariantMap m_month;
+    bool m_monthLoading = false;
+    bool m_monthRequested = false;
+
+    // Rolling graph series + whether the live stream is currently extending them.
+    Series m_grid;
+    Series m_charge;
+    bool m_graphLive = false;
+    bool m_historyLoading = false;
+
+    static constexpr qint64 kWindowMs = 60LL * 60 * 1000;  // 1 h past-hour window
+};
+
+#endif  // FRONTEND_V2_CHARGINGDATA_HH

--- a/frontend_v2/core/protocol.hh
+++ b/frontend_v2/core/protocol.hh
@@ -79,6 +79,53 @@ inline constexpr quint8 TRIP_SUMMARY = 0x7B;      // B->F: trip_id(8B) + status(
 inline constexpr quint8 TRIP_GET_SERIES = 0x7C;   // F->B: start_ms(8B) + end_ms(8B) + id(len(2B)+UTF-8)
 inline constexpr quint8 TRIP_SERIES = 0x7D;       // B->F: trip_id(8B) + id(len(2B)+UTF-8) + status(1B) + count(4B) + count*(ts_ms(8B)+value(8B double))
 
+// MyEnergi (Zappi) charger live stream (backend -> frontend broadcast). A sequence of
+// (sub_id(1B) + value) pairs; each fixed-width sub_id implies its value width. The one
+// variable-width sub_id, CHARGER_RAW_JSON, is length-prefixed (4B). Mirror of protocol.py.
+inline constexpr quint8 CHARGER_STREAM = 0x50;
+inline constexpr quint8 CHARGER_STATUS = 0x51;            // uint8 (CHARGER_STATUS_*)
+inline constexpr quint8 CHARGER_PLUG_STATUS = 0x52;       // uint8 (CHARGER_PLUG_*)
+inline constexpr quint8 CHARGER_MODE = 0x53;              // uint8 (CHARGER_MODE_*)
+inline constexpr quint8 CHARGER_CHARGE_POWER = 0x54;      // float64 W
+inline constexpr quint8 CHARGER_SESSION_ENERGY = 0x55;    // float64 kWh
+inline constexpr quint8 CHARGER_SUPPLY_VOLTAGE = 0x56;    // uint16 V
+inline constexpr quint8 CHARGER_GRID_POWER = 0x57;        // float64 W (+import/-export)
+inline constexpr quint8 CHARGER_GENERATED_POWER = 0x58;   // float64 W (solar/PV)
+inline constexpr quint8 CHARGER_SUPPLY_FREQUENCY = 0x59;  // float64 Hz
+inline constexpr quint8 CHARGER_L1_PHASE = 0x5A;          // uint8
+inline constexpr quint8 CHARGER_RAW_JSON = 0x5F;          // len(4B) + UTF-8 JSON (full raw Zappi payload)
+
+// CHARGER_STATUS enum (maps pymyenergi Zappi.status)
+inline constexpr quint8 CHARGER_STATUS_UNKNOWN = 0;
+inline constexpr quint8 CHARGER_STATUS_PAUSED = 1;
+inline constexpr quint8 CHARGER_STATUS_CHARGING = 2;
+inline constexpr quint8 CHARGER_STATUS_COMPLETED = 3;
+// CHARGER_PLUG_STATUS enum
+inline constexpr quint8 CHARGER_PLUG_UNKNOWN = 0;
+inline constexpr quint8 CHARGER_PLUG_DISCONNECTED = 1;
+inline constexpr quint8 CHARGER_PLUG_CONNECTED = 2;
+inline constexpr quint8 CHARGER_PLUG_WAITING = 3;
+inline constexpr quint8 CHARGER_PLUG_READY = 4;
+inline constexpr quint8 CHARGER_PLUG_CHARGING = 5;
+inline constexpr quint8 CHARGER_PLUG_FAULT = 6;
+// CHARGER_MODE enum
+inline constexpr quint8 CHARGER_MODE_UNKNOWN = 0;
+inline constexpr quint8 CHARGER_MODE_FAST = 1;
+inline constexpr quint8 CHARGER_MODE_ECO = 2;
+inline constexpr quint8 CHARGER_MODE_ECO_PLUS = 3;
+inline constexpr quint8 CHARGER_MODE_STOPPED = 4;
+
+// Charging-losses / month request/response + charger telemetry history (the Charging
+// view). All replied to this client only. Keep in lockstep with protocol.py.
+inline constexpr quint8 CHARGING_GET_LIST = 0x80;    // F->B: start_ms(8B) + end_ms(8B)
+inline constexpr quint8 CHARGING_LIST = 0x81;        // B->F: req_start(8B)+req_end(8B)+count(2B)+count*(start(8B)+end(8B)+charger_kwh(8B))
+inline constexpr quint8 CHARGING_GET_SUMMARY = 0x82; // F->B: start_ms(8B) + end_ms(8B)
+inline constexpr quint8 CHARGING_SUMMARY = 0x83;     // B->F: session_id(8B)+status(1B)+start(8B)+end(8B)+9*double
+inline constexpr quint8 CHARGING_GET_MONTH = 0x84;   // F->B: (empty)
+inline constexpr quint8 CHARGING_MONTH = 0x85;       // B->F: status(1B) + 12*double (charger_kwh, car_kwh, wasted_kwh, efficiency_pct, car_wh_per_km, charger_wh_per_km, driving_kwh, km_month, session_count, total_charge_s, charging_cost_eur, home_grid_kwh)
+inline constexpr quint8 CHARGER_GET_HISTORY = 0x86;  // F->B: range_code(1B)+id(len(2B)+UTF-8)+start(8B)+end(8B)
+inline constexpr quint8 CHARGER_HISTORY = 0x87;      // B->F: id(len(2B)+UTF-8)+status(1B)+count(4B)+count*(ts(8B)+value(8B double))
+
 // History request range codes (mirror the backend _RANGE_* and the QML RangeSelector)
 inline constexpr quint8 HISTORY_RANGE_1H = 0;
 inline constexpr quint8 HISTORY_RANGE_1D = 1;

--- a/frontend_v2/core/protocol.hh
+++ b/frontend_v2/core/protocol.hh
@@ -122,7 +122,7 @@ inline constexpr quint8 CHARGING_LIST = 0x81;        // B->F: req_start(8B)+req_
 inline constexpr quint8 CHARGING_GET_SUMMARY = 0x82; // F->B: start_ms(8B) + end_ms(8B)
 inline constexpr quint8 CHARGING_SUMMARY = 0x83;     // B->F: session_id(8B)+status(1B)+start(8B)+end(8B)+9*double
 inline constexpr quint8 CHARGING_GET_MONTH = 0x84;   // F->B: (empty)
-inline constexpr quint8 CHARGING_MONTH = 0x85;       // B->F: status(1B) + 12*double (charger_kwh, car_kwh, wasted_kwh, efficiency_pct, car_wh_per_km, charger_wh_per_km, driving_kwh, km_month, session_count, total_charge_s, charging_cost_eur, home_grid_kwh)
+inline constexpr quint8 CHARGING_MONTH = 0x85;       // B->F: status(1B) + 13*double (charger_kwh, car_kwh, wasted_kwh, efficiency_pct, car_wh_per_km, charger_wh_per_km, driving_kwh, km_month, session_count, total_charge_s, charging_cost_eur, home_grid_kwh, home_cost_eur)
 inline constexpr quint8 CHARGER_GET_HISTORY = 0x86;  // F->B: range_code(1B)+id(len(2B)+UTF-8)+start(8B)+end(8B)
 inline constexpr quint8 CHARGER_HISTORY = 0x87;      // B->F: id(len(2B)+UTF-8)+status(1B)+count(4B)+count*(ts(8B)+value(8B double))
 

--- a/frontend_v2/items/charging/ChargingGraphCard.qml
+++ b/frontend_v2/items/charging/ChargingGraphCard.qml
@@ -1,0 +1,50 @@
+import QtQuick
+import frontend_v2
+
+// A past-hour power graph in the Charging view: the shared HistoryGraph fed from one of
+// the Charging singleton's rolling series (grid or charge power), in the minimalistic
+// translucent-grey card. Pure renderer — ChargingView wires the singleton's ready/tick
+// signals to reload()/advance() (mirrors TripGraphCard's onSeriesReady → reloadFull).
+Item {
+    id: root
+
+    property string title: ""
+    property string unit: "W"
+    // A { points, minX, maxX, minY, maxY, count } map from Charging.gridSeries/.chargeSeries.
+    property var series: ({})
+
+    function reload() { graph.reloadFull() }
+    function advance() { graph.advanceLive() }
+
+    Rectangle {
+        anchors.fill: parent
+        radius: Theme.tripCardRadius
+        color: Theme.tripCardBg
+        border.width: 1
+        border.color: Theme.tripCardBorder
+    }
+
+    HistoryGraph {
+        id: graph
+        anchors.fill: parent
+        showBackground: false
+        unit: root.unit
+        pointsData: root.series && root.series.points ? root.series.points : []
+        dataMinX: root.series && root.series.minX !== undefined ? root.series.minX : 0
+        dataMaxX: root.series && root.series.maxX !== undefined ? root.series.maxX : 1
+        dataMinY: root.series && root.series.minY !== undefined ? root.series.minY : 0
+        dataMaxY: root.series && root.series.maxY !== undefined ? root.series.maxY : 1
+        dataCount: root.series && root.series.count !== undefined ? root.series.count : 0
+        dataLoading: Charging.historyLoading
+    }
+
+    Text {
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.margins: 16
+        text: root.title
+        color: Theme.dataLabelTitle
+        font.family: Theme.fontFamily
+        font.pixelSize: 16
+    }
+}

--- a/frontend_v2/items/charging/ChargingLiveCard.qml
+++ b/frontend_v2/items/charging/ChargingLiveCard.qml
@@ -1,0 +1,65 @@
+import QtQuick
+import QtQuick.Layouts
+import frontend_v2
+
+// Compact live charger status strip for the Charging view: current state + session
+// energy + live charge/grid power, from the CHARGER_STREAM broadcast. Minimalistic
+// translucent-grey card matching the stat tiles. Updates in place (no delegate churn):
+// each stat binds its own value, so only the changed field repaints per frame.
+Item {
+    id: root
+
+    function has(v) { return v !== undefined && v !== null && !isNaN(v) }
+    function statusText(s) {
+        switch (s) {
+            case 2: return qsTr("Lataa")
+            case 1: return qsTr("Tauolla")
+            case 3: return qsTr("Valmis")
+            default: return "—"
+        }
+    }
+    function power(w) { return has(w) ? Math.round(w) + " W" : "—" }
+    function energy(kwh) { return has(kwh) ? kwh.toFixed(2) + " kWh" : "—" }
+
+    // One title-over-value stat in the row.
+    component LiveStat: Column {
+        property string t: ""
+        property string v: "—"
+        Layout.fillWidth: true
+        Layout.alignment: Qt.AlignVCenter
+        spacing: 2
+        Text {
+            text: parent.t
+            color: Theme.dataLabelTitle
+            font.family: Theme.fontFamily
+            font.pixelSize: 14
+        }
+        Text {
+            text: parent.v
+            color: Theme.dataLabelValue
+            font.family: Theme.fontFamily
+            font.pixelSize: 22
+            font.bold: true
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        radius: Theme.tripCardRadius
+        color: Theme.tripCardBg
+        border.width: 1
+        border.color: Theme.tripCardBorder
+    }
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: 18
+        anchors.rightMargin: 18
+        spacing: 12
+
+        LiveStat { t: qsTr("Tila");       v: root.statusText(Charging.status) }
+        LiveStat { t: qsTr("Istunto");    v: root.energy(Charging.sessionEnergyKwh) }
+        LiveStat { t: qsTr("Latausteho"); v: root.power(Charging.chargePowerW) }
+        LiveStat { t: qsTr("Verkkoteho"); v: root.power(Charging.gridPowerW) }
+    }
+}

--- a/frontend_v2/items/charging/ChargingStatsGrid.qml
+++ b/frontend_v2/items/charging/ChargingStatsGrid.qml
@@ -59,11 +59,18 @@ Item {
         }
         TripStatCard {
             Layout.fillWidth: true; Layout.fillHeight: true
-            title: qsTr("Kustannus");       value: root.num(root.s.chargingCostEur, "€", 2)
+            title: qsTr("Latauskulut");     value: root.num(root.s.chargingCostEur, "€", 2)
         }
         TripStatCard {
             Layout.fillWidth: true; Layout.fillHeight: true
             title: qsTr("Kotitalous");      value: root.num(root.s.homeGridKwh, "kWh", 1)
+        }
+        // Total home electricity cost this month (all grid import * flat tariff),
+        // spanning both columns as a footer.
+        TripStatCard {
+            Layout.fillWidth: true; Layout.fillHeight: true
+            Layout.columnSpan: 2
+            title: qsTr("Sähkölasku");      value: root.num(root.s.homeCostEur, "€", 2)
         }
     }
 }

--- a/frontend_v2/items/charging/ChargingStatsGrid.qml
+++ b/frontend_v2/items/charging/ChargingStatsGrid.qml
@@ -1,0 +1,69 @@
+import QtQuick
+import QtQuick.Layouts
+import frontend_v2
+
+// The Charging-view month-to-date stats: a 2×5 grid of stat tiles (reusing TripStatCard)
+// bound to Charging.monthSummary. Every value degrades to "—" when its metric is NaN /
+// missing, so a partial-data month still renders cleanly. Energies are already in kWh
+// (unlike the trip grid's Wh), so they format directly.
+Item {
+    id: root
+
+    readonly property var s: Charging.monthSummary
+
+    function has(v) { return v !== undefined && v !== null && !isNaN(v) }
+    function num(v, unit, dec) {
+        return has(v) ? v.toFixed(dec) + (unit ? " " + unit : "") : "—"
+    }
+    function hours(sec) {
+        return has(sec) ? (sec / 3600).toFixed(1) + " h" : "—"
+    }
+
+    GridLayout {
+        anchors.fill: parent
+        columns: 2
+        rowSpacing: 10
+        columnSpacing: 10
+
+        TripStatCard {
+            Layout.fillWidth: true; Layout.fillHeight: true
+            title: qsTr("Laturin energia"); value: root.num(root.s.chargerKwh, "kWh", 1)
+        }
+        TripStatCard {
+            Layout.fillWidth: true; Layout.fillHeight: true
+            title: qsTr("Autoon");          value: root.num(root.s.carKwh, "kWh", 1)
+        }
+        TripStatCard {
+            Layout.fillWidth: true; Layout.fillHeight: true
+            title: qsTr("Hukka");           value: root.num(root.s.wastedKwh, "kWh", 1)
+        }
+        TripStatCard {
+            Layout.fillWidth: true; Layout.fillHeight: true
+            title: qsTr("Hyötysuhde");      value: root.num(root.s.efficiencyPct, "%", 0)
+        }
+        TripStatCard {
+            Layout.fillWidth: true; Layout.fillHeight: true
+            title: qsTr("Ajokulutus");      value: root.num(root.s.carWhPerKm, "Wh/km", 0)
+        }
+        TripStatCard {
+            Layout.fillWidth: true; Layout.fillHeight: true
+            title: qsTr("Laturikulutus");   value: root.num(root.s.chargerWhPerKm, "Wh/km", 0)
+        }
+        TripStatCard {
+            Layout.fillWidth: true; Layout.fillHeight: true
+            title: qsTr("Latauskerrat");    value: root.num(root.s.sessionCount, "", 0)
+        }
+        TripStatCard {
+            Layout.fillWidth: true; Layout.fillHeight: true
+            title: qsTr("Latausaika");      value: root.hours(root.s.totalChargeS)
+        }
+        TripStatCard {
+            Layout.fillWidth: true; Layout.fillHeight: true
+            title: qsTr("Kustannus");       value: root.num(root.s.chargingCostEur, "€", 2)
+        }
+        TripStatCard {
+            Layout.fillWidth: true; Layout.fillHeight: true
+            title: qsTr("Kotitalous");      value: root.num(root.s.homeGridKwh, "kWh", 1)
+        }
+    }
+}

--- a/frontend_v2/main.cpp
+++ b/frontend_v2/main.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "core/appconfig.hh"
+#include "core/charging/chargingdata.hh"
 #include "core/logger.hh"
 #include "core/media/mediadata.hh"
 #include "core/media/mediaimageprovider.hh"
@@ -55,6 +56,9 @@ int main(int argc, char* argv[]) {
     // Trip viewer: request/response over the same socket (TRIP_* codes). No live
     // data, so it only needs the ServerClient.
     TripsData tripsData(&serverClient);
+    // Charging view: live CHARGER_STREAM (myenergi) + charger-history / month
+    // request-response over the same socket.
+    ChargingData chargingData(&serverClient);
     auto mediaCache = std::make_shared<MediaImageCache>();
     MediaData mediaData(&serverClient, mediaCache);
     WeatherData weatherData(&serverClient);
@@ -73,6 +77,7 @@ int main(int argc, char* argv[]) {
     qmlRegisterSingletonInstance("frontend_v2", 1, 0, "Tesla", &teslaData);
     qmlRegisterSingletonInstance("frontend_v2", 1, 0, "History", &teslaHistory);
     qmlRegisterSingletonInstance("frontend_v2", 1, 0, "Trips", &tripsData);
+    qmlRegisterSingletonInstance("frontend_v2", 1, 0, "Charging", &chargingData);
     qmlRegisterSingletonInstance("frontend_v2", 1, 0, "Media", &mediaData);
     qmlRegisterSingletonInstance("frontend_v2", 1, 0, "Weather", &weatherData);
     qmlRegisterSingletonInstance("frontend_v2", 1, 0, "Notifications", &notificationHandler);

--- a/frontend_v2/resources/icons/charger.svg
+++ b/frontend_v2/resources/icons/charger.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10 8V11M14 8V11M12 21V16M12 21C16.9706 21 21 16.9706 21 12C21 7.02944 16.9706 3 12 3C7.02944 3 3 7.02944 3 12C3 16.9706 7.02944 21 12 21ZM8 11H16V12.8C16 13.9201 16 14.4802 15.782 14.908C15.5903 15.2843 15.2843 15.5903 14.908 15.782C14.4802 16 13.9201 16 12.8 16H11.2C10.0799 16 9.51984 16 9.09202 15.782C8.71569 15.5903 8.40973 15.2843 8.21799 14.908C8 14.4802 8 13.9201 8 12.8V11Z" stroke="#000000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend_v2/views/ChargingView.qml
+++ b/frontend_v2/views/ChargingView.qml
@@ -1,0 +1,95 @@
+import QtQuick
+import QtQuick.Layouts
+import frontend_v2
+
+// Charging view ("Lataus"): the myenergi charger.
+//   • left column (60% width): two stacked past-hour power graphs (grid + charge power);
+//   • right column (40% width): a live status strip on top, then the month-to-date stats
+//     grid (2×5 of the computed month metrics).
+// Matches the Trips view's minimalistic translucent-grey card style. State is preserved
+// across view switches (kept alive, no reload on re-show); the live graph buffering +
+// month refresh are gated on isCurrent so a hidden view does no per-frame work.
+Rectangle {
+    id: view
+
+    property bool isCurrent: false
+    color: Theme.tripBackground
+
+    // Usable width for the two columns (view minus the outer margins and the 10px gap
+    // between the columns); split 60/40, matching TripsView.
+    readonly property real contentWidth: width - 2 * Theme.gridMargin - 10
+
+    // Seed/refresh the graphs + month stats when shown; freeze the live graph buffers
+    // when hidden (the CHARGER_STREAM tiles in the live strip keep updating regardless).
+    onIsCurrentChanged: {
+        if (isCurrent) {
+            Charging.startLive()
+            Charging.requestMonth()
+        } else {
+            Charging.stopLive()
+        }
+    }
+
+    // Left column (60%): two past-hour power graphs stacked evenly.
+    ColumnLayout {
+        id: leftColumn
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.leftMargin: Theme.gridMargin
+        anchors.topMargin: Theme.gridMargin
+        anchors.bottomMargin: Theme.gridMargin
+        width: view.contentWidth * 0.60
+        spacing: 10
+
+        ChargingGraphCard {
+            id: gridCard
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            title: qsTr("Verkkoteho") + " (W)"
+            unit: "W"
+            series: Charging.gridSeries
+        }
+        ChargingGraphCard {
+            id: chargeCard
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            title: qsTr("Latausteho") + " (W)"
+            unit: "W"
+            series: Charging.chargeSeries
+        }
+    }
+
+    // Wire each series' ready (fresh seed → reset + refill) and tick (live append →
+    // advance without clobbering zoom) signals to its graph card.
+    Connections {
+        target: Charging
+        function onGridReady() { gridCard.reload() }
+        function onGridTick() { gridCard.advance() }
+        function onChargeReady() { chargeCard.reload() }
+        function onChargeTick() { chargeCard.advance() }
+    }
+
+    // Right column (40%): live status strip on top, then the month stats grid.
+    ColumnLayout {
+        anchors.left: leftColumn.right
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.bottom: parent.bottom
+        anchors.leftMargin: 10
+        anchors.rightMargin: Theme.gridMargin
+        anchors.topMargin: Theme.gridMargin
+        anchors.bottomMargin: Theme.gridMargin
+        spacing: 10
+
+        ChargingLiveCard {
+            Layout.fillWidth: true
+            Layout.preferredHeight: 72
+        }
+
+        ChargingStatsGrid {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+    }
+}

--- a/scripts/build-frontend.cmd
+++ b/scripts/build-frontend.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Wrapper so the PowerShell build script runs from cmd.exe. Forwards all args.
+powershell -ExecutionPolicy Bypass -File "%~dp0build-frontend.ps1" %*

--- a/scripts/build-frontend.ps1
+++ b/scripts/build-frontend.ps1
@@ -1,0 +1,124 @@
+<#
+.SYNOPSIS
+    Configure + build (and optionally run) frontend_v2 from a plain PowerShell,
+    without opening Qt Creator. Builds the frontend_v2 of whichever checkout you
+    run it from — main checkout or a worktree.
+
+.DESCRIPTION
+    Imports the MSVC x64 environment (vcvars64.bat, located via vswhere), detects
+    the newest Qt 6 msvc2022_64 kit, then runs a Ninja CMake configure + build of
+    the appfrontend_v2 target into <repo>\frontend_v2\build. Object files are
+    reused via sccache automatically when it is installed (see the compiler-cache
+    block in frontend_v2/CMakeLists.txt).
+
+.PARAMETER Config
+    CMake build type: Debug (default), Release, or RelWithDebInfo.
+
+.PARAMETER QtPrefix
+    Qt kit path. Default: newest D:\Qt\6.*.*\msvc2022_64.
+
+.PARAMETER Run
+    Launch appfrontend_v2.exe after a successful build.
+
+.PARAMETER Fullscreen
+    With -Run, start the frontend fullscreen (TESLA_HOMEDASH_FULLSCREEN=1).
+
+.PARAMETER Clean
+    Delete the build directory first (forces a full reconfigure + rebuild).
+
+.EXAMPLE
+    .\scripts\build-frontend.ps1 -Run
+.EXAMPLE
+    .\scripts\build-frontend.ps1 -Config Release -Clean
+#>
+[CmdletBinding()]
+param(
+    [ValidateSet('Debug', 'Release', 'RelWithDebInfo')]
+    [string]$Config = 'Debug',
+    [string]$QtPrefix,
+    [switch]$Run,
+    [switch]$Fullscreen,
+    [switch]$Clean
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Refresh PATH from the machine + user environment so a freshly-installed sccache
+# is visible without opening a new terminal.
+$env:PATH = [System.Environment]::GetEnvironmentVariable('PATH', 'Machine') + ';' +
+            [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+
+# --- Locate the checkout we are building (main or worktree) ---
+$repoRoot = (git rev-parse --show-toplevel).Trim()
+$src   = Join-Path $repoRoot 'frontend_v2'
+$build = Join-Path $src 'build'
+if (-not (Test-Path (Join-Path $src 'CMakeLists.txt'))) {
+    throw "No frontend_v2\CMakeLists.txt under $repoRoot"
+}
+
+# --- Detect the Qt kit ---
+if (-not $QtPrefix) {
+    $qtRoot = 'D:\Qt'
+    $kit = Get-ChildItem $qtRoot -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match '^6\.\d+\.\d+$' -and (Test-Path (Join-Path $_.FullName 'msvc2022_64')) } |
+        Sort-Object { [version]$_.Name } -Descending | Select-Object -First 1
+    if (-not $kit) { throw "No Qt 6 msvc2022_64 kit found under $qtRoot. Pass -QtPrefix." }
+    $QtPrefix = Join-Path $kit.FullName 'msvc2022_64'
+}
+Write-Host "Qt kit:  $QtPrefix" -ForegroundColor Cyan
+
+# --- Import the MSVC x64 build environment (puts cl.exe on PATH) ---
+$pf86    = [System.Environment]::GetEnvironmentVariable('ProgramFiles(x86)')
+$vswhere = Join-Path $pf86 'Microsoft Visual Studio\Installer\vswhere.exe'
+if (-not (Test-Path $vswhere)) { throw "vswhere not found at $vswhere" }
+$vsPath = (& $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath).Trim()
+$vcvars = Join-Path $vsPath 'VC\Auxiliary\Build\vcvars64.bat'
+if (-not (Test-Path $vcvars)) { throw "vcvars64.bat not found at $vcvars" }
+cmd /c "`"$vcvars`" && set" | ForEach-Object {
+    if ($_ -match '^([^=]+)=(.*)$') {
+        [System.Environment]::SetEnvironmentVariable($matches[1], $matches[2])
+    }
+}
+Write-Host "MSVC:    $vsPath" -ForegroundColor DarkGray
+
+# --- Pick cmake + ninja (Qt bundles both) ---
+$cmake = 'D:\Qt\Tools\CMake_64\bin\cmake.exe'
+if (-not (Test-Path $cmake)) { $cmake = (Get-Command cmake -ErrorAction SilentlyContinue).Source }
+if (-not $cmake) { throw 'cmake not found (install it or put it on PATH).' }
+$ninja = (Get-Command ninja -ErrorAction SilentlyContinue).Source
+if (-not $ninja) { $ninja = 'D:\Qt\Tools\Ninja\ninja.exe' }
+
+if ($Clean -and (Test-Path $build)) {
+    Write-Host "Cleaning $build" -ForegroundColor Yellow
+    Remove-Item -Recurse -Force $build
+}
+
+# --- Configure (CMake no-ops if already configured and unchanged) ---
+$cfgArgs = @('-S', $src, '-B', $build, '-G', 'Ninja',
+             "-DCMAKE_PREFIX_PATH=$QtPrefix", "-DCMAKE_BUILD_TYPE=$Config")
+if (Test-Path $ninja) { $cfgArgs += "-DCMAKE_MAKE_PROGRAM=$ninja" }
+Write-Host "Configuring ($Config) ..." -ForegroundColor Cyan
+& $cmake @cfgArgs
+if ($LASTEXITCODE -ne 0) { throw 'CMake configure failed.' }
+
+# --- Build ---
+Write-Host 'Building appfrontend_v2 ...' -ForegroundColor Cyan
+& $cmake --build $build --target appfrontend_v2
+if ($LASTEXITCODE -ne 0) { throw 'Build failed.' }
+
+$exe = Join-Path $build 'appfrontend_v2.exe'
+Write-Host ''
+Write-Host "Build OK -> $exe" -ForegroundColor Green
+
+# --- sccache stats, if present ---
+$scc = (Get-Command sccache -ErrorAction SilentlyContinue).Source
+if ($scc) { & $scc --show-stats 2>$null | Select-String 'Compile requests|Cache hits|Cache misses' }
+
+# --- Optional run ---
+if ($Run) {
+    if (-not (Test-Path $exe)) { throw "Executable not found: $exe" }
+    $env:PATH = "$QtPrefix\bin;$env:PATH"            # so the exe finds Qt6*.dll
+    if ($Fullscreen) { $env:TESLA_HOMEDASH_FULLSCREEN = '1' }
+    Write-Host "Launching $exe" -ForegroundColor Cyan
+    & $exe
+}

--- a/scripts/finish-session.cmd
+++ b/scripts/finish-session.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Wrapper so the PowerShell finish script runs from cmd.exe. Forwards all args.
+powershell -ExecutionPolicy Bypass -File "%~dp0finish-session.ps1" %*

--- a/scripts/new-session.cmd
+++ b/scripts/new-session.cmd
@@ -1,0 +1,3 @@
+@echo off
+rem Wrapper so the PowerShell session script runs from cmd.exe. Forwards all args.
+powershell -ExecutionPolicy Bypass -File "%~dp0new-session.ps1" %*


### PR DESCRIPTION
## Summary

Integrates a myenergi **Zappi** home charger and adds a new **Charging (Lataus)** view to the dashboard, closing the loop on charging telemetry, session analysis, and electricity cost.

Backend:
- **`myenergi_service`** — polls the Zappi via `pymyenergi` (cloud digest auth), broadcasts live state as `CHARGER_STREAM` (`0x50`), and logs `GridPower`/`ChargePower` every poll + `ChargeAdded` while charging to the `myenergi_data` measurement. Optional — skipped when `.env` creds are unset. Two poll cadences (idle/active).
- **`charging_service`** (`ChargingLoader` + `ChargingSession`) — derives charging sessions **on demand** from stored `DetailedChargeState` history joined to the logged charger energy. Serves `CHARGING_GET_LIST` / `_SUMMARY` / `_MONTH` and `CHARGER_GET_HISTORY` (`0x80`–`0x87`).
- **Per-session charger energy = sum of positive `ChargeAdded` increments** (not the in-window max — the accumulator can carry in energy predating the Tesla-detected session, so max double-counts; this was a real bug, fixed in `9236798`).
- **Month-to-date aggregate** (`CHARGING_MONTH`, 13 doubles) + **flat-tariff cost tiles** (`electricityPriceEurPerKwh` → `Latauskulut` charging cost and `Sähkölasku` total home electricity cost). Home grid import via a positive-`GridPower` `integral()`.
- InfluxDB helpers: `write_charger_data`, `read_charger_data_property`, `read_grid_import_kwh_month`.
- Registers the myenergi / charging / trip / server loggers so their logs actually emit (`726905d`).

Frontend (`frontend_v2`):
- New **"Lataus"** view: live charger card, past-hour power graphs, and month stat grid.
- `core/charging/chargingdata.{hh,cpp}` datahandler + `core/protocol.hh` codes; `items/charging/*` cards; `resources/icons/charger.svg` dock icon.

Tooling / docs:
- CLI build + session helper shims (`scripts/build-frontend.{ps1,cmd}`, `new-session.cmd`, `finish-session.cmd`).
- `CLAUDE.md` updated for the charger/charging protocol, services, cost feature, and currency marker.

## Reason

Closes #7 (Home charger (Zappi) API integration). Brings home-charging data — live state, per-session energy/loss breakdown, and month-to-date consumption + cost — onto the dashboard alongside the existing Tesla / media / weather surfaces.

Spot/hourly (Nord Pool) pricing is out of scope here and tracked separately in #12; this PR ships a flat €/kWh tariff.

## Manual verification

Backend:
- `python -m compileall backend/src` passes.
- With `MYENERGI_HUB_SERIAL` / `MYENERGI_API_KEY` set, start the stack and confirm: `CHARGER_STREAM` broadcasts live Zappi state; `myenergi_data` accrues `GridPower`/`ChargePower` each poll and `ChargeAdded` while charging.
- With the creds **unset**, confirm the charger service is skipped and the rest of the stack still runs.
- Exercise `CHARGING_GET_LIST` / `_SUMMARY` / `_MONTH` and `CHARGER_GET_HISTORY` from a connected client; verify per-session charger energy matches the sum-of-positive-increments (not the accumulator max).

Frontend (verified locally by maintainer — agent does not build the frontend):
- Build `frontend_v2` and open the **Lataus** view.
- Confirm the live charger card reflects `CHARGER_STREAM`, the past-hour power graphs render, and the month stat grid shows energy + `Latauskulut` / `Sähkölasku` cost tiles (or "—" when `electricityPriceEurPerKwh` is absent).

## Screenshots

_UI screenshots to be added by the maintainer (Lataus view: live card, past-hour graphs, month stat grid)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)