### PR TITLE
Add: Nord Pool spot-price cost estimation (issue #12)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,9 @@ backend/
       trip.py, trip_loader.py     # On-demand trip detection from stored telemetry (the Trips view)
     charging_service/
       charging_loader.py          # On-demand charging-session detection (DetailedChargeState segmentation)
-      charging_session.py         # Per-session energy + loss breakdown (charger vs AC-in vs battery)
+      charging_session.py         # Per-session energy + loss breakdown (charger vs AC-in vs battery) + spot cost
+      spot_price.py               # SpotPriceProvider — Nord Pool FI spot price fetch/cache/convert (sähkötin.fi) + pricing helpers
+      spot_price_service.py       # SpotPriceService — hourly live spot-price broadcast (SPOT_PRICE_STREAM)
     myenergi_service/
       myenergi_service.py         # myenergi Zappi cloud poll → CHARGER_STREAM broadcast + myenergi_data logging
     influxdb_service/
@@ -200,7 +202,13 @@ Parsed once by `Config` and injected into every service. Keys:
 - `trip` (optional) — trip-detection tunables: `min_stop_minutes`, `min_trip_distance_km`.
 - `electricityPriceEurPerKwh` (optional) — flat €/kWh tariff for the Charging view's cost tiles
   (`Latauskulut` = charging cost, `Sähkölasku` = total home electricity cost); `null`/absent → "—".
-  Spot/hourly (Nord Pool) pricing is tracked in issue #12.
+  Now a **fallback**: used per-hour when spot pricing is off or a given hour has no spot price.
+- `spotPrice` (optional, issue #12) — Nord Pool FI hourly spot pricing for the cost tiles + the live
+  price tile: `enabled` (master switch; `false` → flat-tariff pricing, no live service),
+  `vatPercent` (Finnish electricity VAT, default `25.5`), `marginCentsPerKwh` (seller margin c/kWh
+  added before VAT), `baseUrl` (the no-key sähkötin.fi range endpoint; swappable for another source).
+  All-in €/kWh for an hour = `(spot + marginCentsPerKwh/100) × (1 + vatPercent/100)`. Prices are
+  fetched on demand (no self-logging) — historical hours price past sessions retroactively.
 
 ### Frontend environment variables (read only by `AppConfig::load()`)
 All optional; defaults match the embedded target.
@@ -261,11 +269,12 @@ payload[1..N-1] = type-specific data
 | `0x80` | CHARGING_GET_LIST | F→B | `start_ms(8B) + end_ms(8B)` |
 | `0x81` | CHARGING_LIST | B→F | `req_start(8B)+req_end(8B)+count(2B)` + count×(`start(8B)+end(8B)+charger_kwh(8B double)`) |
 | `0x82` | CHARGING_GET_SUMMARY | F→B | `start_ms(8B) + end_ms(8B)` |
-| `0x83` | CHARGING_SUMMARY | B→F | `session_id(8B)+status(1B)+start(8B)+end(8B)` + 9×`double` (per-session losses) |
+| `0x83` | CHARGING_SUMMARY | B→F | `session_id(8B)+status(1B)+start(8B)+end(8B)` + 11×`double` (per-session losses + `cost_eur` + `avg_price_eur_per_kwh`) |
 | `0x84` | CHARGING_GET_MONTH | F→B | (empty) |
 | `0x85` | CHARGING_MONTH | B→F | `status(1B)` + 13×`double` (month aggregate — see below) |
 | `0x86` | CHARGER_GET_HISTORY | F→B | `range_code(1B) + id_len(2B)+id + start_ms(8B) + end_ms(8B)` |
 | `0x87` | CHARGER_HISTORY | B→F | `id_len(2B)+id + status(1B) + count(4B)` + count×(`ts_ms(8B)+value(8B double)`) — reads `myenergi_data` |
+| `0x88` | SPOT_PRICE_STREAM | B→F | live spot price broadcast: `status(1B) + hour_start_ms(8B) + spot(8B double) + all_in(8B double)` (raw wholesale + VAT/margin all-in €/kWh; both NaN when status 0) |
 
 (Trip codes `0x74`–`0x7D` — the Trips view — are omitted from this table; they mirror the History
 request/response shape. See the `frontend_v2` memory.)
@@ -295,9 +304,11 @@ the Zappi's live state, a weather-style sequence of `sub_id(1B) + value` pairs: 
 `0x5F` the full raw pymyenergi payload as `len(4B)+UTF-8 JSON` (every field, most unused — the one
 length-prefixed sub-id, so an unknown fixed-width sub-id can't be skipped and stops the parse). The
 `0x80`–`0x87` codes are **request/response** (reply to the requesting client only), served by
-`charging_service` from stored telemetry + `myenergi_data`. `CHARGING_MONTH`'s 13 doubles, in order:
+`charging_service` from stored telemetry + `myenergi_data`; `0x88` (`SPOT_PRICE_STREAM`) is a
+**broadcast** of the live hourly spot price (see §5.2.7). `CHARGING_MONTH`'s 13 doubles, in order:
 charger_kwh, car_kwh, wasted_kwh, efficiency_pct, car_wh_per_km, charger_wh_per_km, driving_kwh,
 km_month, session_count, total_charge_s, charging_cost_eur, home_grid_kwh, home_cost_eur (any → NaN → "—").
+Both cost fields are now **spot-priced per hour** (flat-tariff fallback) — see §5.2.7.
 
 **Adding a telemetry field** — update these in sync:
 1. `config.json` `tesla data` — new entry with a unique `stream_id`.
@@ -439,9 +450,10 @@ dropping the leading null windows, but is currently unused), and `read_last_valu
 `last()` query bounded by `stop` — the held value before an empty window, used to boundary-fill the
 History graph with a flat line). For the myenergi charger it adds `write_charger_data` (the
 `myenergi_data` measurement), `read_charger_data_property` (raw charger history), and
-`read_grid_import_kwh_month` (a positive-`GridPower` `integral()` → the month's home grid import;
-`integral()` needs the range's `_start` column, so do **not** `keep()`-drop columns before it). Read
-failures degrade to `None` rather than crashing the app. **Talks to:** InfluxDB,
+`read_grid_import_kwh_hourly` (reuses the raw `GridPower` read + the module-level pure
+`integrate_power_series_hourly` — a trapezoidal per-UTC-hour integral, export clamped to 0 → a
+`{utc_hour_ms: kwh}` map; the month home-import total is `sum(...)` and the spot-cost path dots it
+with hourly prices). Read failures degrade to `None` rather than crashing the app. **Talks to:** InfluxDB,
 `Vehicle`. *Flux queries interpolate `data_property_id` via f-strings gated by the `_SAFE_ID` regex
 `^[A-Za-z0-9_\-]+$`, and `aggregate_window` by `_SAFE_WINDOW` (`^[1-9][0-9]*[smhd]$`) — keep both
 guards; they're the only thing preventing injection if non-config input ever reaches these paths.*
@@ -471,8 +483,21 @@ guards; they're the only thing preventing injection if non-config input ever rea
   in the window** (NOT the in-window max: the myenergi accumulator can carry a value in from charging
   that predates the Tesla-detected session, so a max double-counts — this was a real bug). `month_summary`
   sums the sessions' charger/battery energy + the tesla month-counter deltas (`LifetimeEnergyUsed`,
-  `Odometer`) for consumption/km; the `CHARGING_GET_MONTH` handler multiplies energy by the flat
-  `electricityPriceEurPerKwh` tariff for the cost tiles. **Talks to:** `InfluxDBHandler`, `Server`.
+  `Odometer`) for consumption/km. **Talks to:** `InfluxDBHandler`, `Server`.
+- **Spot pricing (issue #12).** **`spot_price.py`** (`SpotPriceProvider`) fetches Nord Pool FI hourly
+  spot prices from the no-key **sähkötin.fi** range endpoint (`?start&end`, raw €/MWh, UTC hours),
+  converts to an all-in `(spot + margin) × (1 + VAT)` €/kWh, and caches immutable past hours — so a
+  session from days ago is priced retroactively **without self-logging prices**. The module also holds
+  the pure pricing helper `price_hourly_energy` (dot energy-by-hour with price, flat-tariff fallback).
+  Cost now lives in the **loader/session** (not the month handler): `ChargingSession.summary()` buckets
+  its `ChargeAdded` increments by UTC hour (`bucket_positive_increments_by_hour`) and prices each →
+  `cost_eur`/`avg_price_eur_per_kwh`; `month_summary` sums session costs (`charging_cost_eur`) and
+  prices the hourly home import (`home_cost_eur`), each falling back per-hour to the flat
+  `electricityPriceEurPerKwh` tariff (→ NaN → "—" when neither is available). **`spot_price_service.py`**
+  (`SpotPriceService`) is a thin always-on `WeatherService`-style broadcaster: it re-broadcasts the
+  current hour's price as `SPOT_PRICE_STREAM` (`0x88`) hourly + snapshots it on connect. Always
+  constructed (works with no Zappi); `run()` no-ops when `spotPrice.enabled` is false. **Talks to:**
+  sähkötin.fi (aiohttp), `InfluxDBHandler`, `Server`.
 
 ### 5.3 Frontend
 
@@ -646,16 +671,22 @@ a new/renamed service or widget, a protocol change, a build-command change, or a
 invariant. Treat the doc as part of the change, not an afterthought, and bump §7.7.
 
 ### 7.7 Documentation currency
-This guide and `README.md` are current as of commit **`966a04a`** ("Add: fixed-price electricity
-cost"), the head of the **charging-stats** work on `feature/charging-stats-backend`: the myenergi
-Zappi integration (`myenergi_service`, `CHARGER_STREAM` `0x50`, `myenergi_data` logging), the
-on-demand **charging-session analysis** (`charging_service`; `CHARGING_*` / `CHARGER_HISTORY`
-`0x80`–`0x87`), the **month-to-date aggregate** (`CHARGING_MONTH`, 13 doubles) and the **flat-tariff
-cost tiles** (`electricityPriceEurPerKwh`; spot pricing is issue #12). Per-session charger energy is
-the **sum of positive `ChargeAdded` increments** (not the in-window max — that double-counted). The
-frontend_v2 "Lataus" view consumes these (out of scope here; see the `frontend_v2` memory). The
-earlier History-graph **empty-window boundary-fill** (`1184b60` / `cc11bb8`) and the `0x70`–`0x73`
-request/response protocol + `(payload, writer)` handler signature (`827824d`) still apply.
+This guide and `README.md` are current as of the **spot-price cost** work on
+`feature/spot-price-cost` (issue #12), which builds on the charging-stats backend: **hourly Nord Pool
+FI spot pricing** for the Charging view's cost tiles + a live current-price tile. New backend modules
+`charging_service/spot_price.py` (`SpotPriceProvider` — no-key sähkötin.fi fetch/cache/convert, all-in
+`(spot + margin) × (1 + VAT)`, retroactive/historical) and `spot_price_service.py` (`SpotPriceService`
+— hourly `SPOT_PRICE_STREAM` `0x88` broadcast). Cost moved from the `CHARGING_GET_MONTH` handler into
+the loader/session: sessions bucket `ChargeAdded` by UTC hour and price each hour; `month_summary`
+sums session costs + prices the hourly home import (new `read_grid_import_kwh_hourly` +
+`integrate_power_series_hourly`, replacing `read_grid_import_kwh_month`). The flat
+`electricityPriceEurPerKwh` is now a per-hour fallback. `CHARGING_SUMMARY` `0x83` grew to **11 doubles**
+(+`cost_eur`, +`avg_price_eur_per_kwh`); `CHARGING_MONTH` `0x85` unchanged (13 doubles, now spot-valued).
+New `spotPrice` config block. Pure cost math is unit-tested in `backend/tests/test_spot_price.py`.
+Predecessor work — the **charging-stats** backend (`966a04a`; myenergi `CHARGER_STREAM` `0x50`,
+`CHARGING_*`/`CHARGER_HISTORY` `0x80`–`0x87`, per-session energy = **sum of positive `ChargeAdded`
+increments**), the History **empty-window boundary-fill** (`1184b60`/`cc11bb8`), and the `0x70`–`0x73`
+request/response + `(payload, writer)` handler signature (`827824d`) — still applies.
 When you land changes that touch behaviour documented here, update this line to the new HEAD commit.
 
 ## 8. Session workflow — main checkout by default, worktree only for parallelism

--- a/backend/src/charging_service/charging_loader.py
+++ b/backend/src/charging_service/charging_loader.py
@@ -16,6 +16,7 @@ import math
 import numpy as np
 
 from .charging_session import CHARGER_ENERGY_ID, ChargingSession, to_flux_time
+from .spot_price import price_hourly_energy
 
 logger = logging.getLogger("charging_service.charging_loader")
 
@@ -170,19 +171,27 @@ class ChargingLoader:
     Arguments:
         influx_handler (InfluxDBHandler): Shared data-access layer. Never queries the
             client directly — only its typed read methods.
-        config (Config): Provides myenergi_config (minSessionEnergyKwh, sessionMergeMinutes).
+        config (Config): Provides myenergi_config (minSessionEnergyKwh, sessionMergeMinutes)
+            and the flat electricityPriceEurPerKwh fallback tariff.
+        spot_provider (SpotPriceProvider | None): Hourly Nord Pool spot pricing for session
+            and month cost. Passed into every ChargingSession; None -> flat-tariff pricing.
     '''
 
     CHARGE_STATE_ID = "DetailedChargeState"
 
-    def __init__(self, influx_handler, config):
+    def __init__(self, influx_handler, config, spot_provider=None):
         self.__influx = influx_handler
+        self.__spot_provider = spot_provider
+        self.__flat_tariff = config.electricity_price_eur_per_kwh
         myenergi_config = config.myenergi_config
         self.__merge_ms = int(myenergi_config["sessionMergeMinutes"]) * 60 * 1000
         self.__min_energy_kwh = float(myenergi_config["minSessionEnergyKwh"])
         logger.info(
-            "ChargingLoader initialized: merge_gap=%s min, min_energy=%.2f kWh",
+            "ChargingLoader initialized: merge_gap=%s min, min_energy=%.2f kWh, "
+            "spot_pricing=%s, flat_tariff=%s",
             myenergi_config["sessionMergeMinutes"], self.__min_energy_kwh,
+            self.__spot_provider is not None and self.__spot_provider.enabled,
+            "unset" if self.__flat_tariff is None else f"{self.__flat_tariff:.4f}",
         )
 
     async def list_sessions(self, start_ms: int, end_ms: int) -> list:
@@ -245,14 +254,41 @@ class ChargingLoader:
                     self.__min_energy_kwh, window_start,
                 )
                 continue
-            session = ChargingSession(self.__influx, window_start, window_end, in_progress)
+            session = ChargingSession(
+                self.__influx, window_start, window_end, in_progress,
+                spot_provider=self.__spot_provider, flat_tariff=self.__flat_tariff,
+            )
             session.seed_charger_kwh(charger_kwh)
+            # Seed the window's ChargeAdded slice from the bulk read too, so the session's
+            # cost path buckets energy by hour without a second query (mirrors the scalar
+            # seed above; both come from the one read this method already did).
+            self.__seed_series(session, charger, window_start, window_end)
             sessions.append(session)
 
         logger.info(
             "Detected %d charging session(s) in [%s, %s]", len(sessions), start_ms, end_ms
         )
         return sessions
+
+    def __seed_series(self, session, charger, window_start_ms: int, window_end_ms: int) -> None:
+        '''
+        Slices the window's ChargeAdded samples out of the bulk-read series and seeds them
+        onto the session, so its cost path buckets delivered energy by hour without a
+        second query. A no-op when no charger series was read (a priced session then reads
+        its own window). Uses the same left/right searchsorted bounds as _window_energy so
+        the seeded slice matches the seeded scalar energy exactly.
+        Arguments:
+            session (ChargingSession): The session to seed.
+            charger (tuple | None): (count, timestamps_ms, values) bulk read, or None.
+            window_start_ms (int): Session window start, epoch-ms UTC.
+            window_end_ms (int): Session window end, epoch-ms UTC.
+        '''
+        if charger is None:
+            return
+        _count, timestamps, values = charger
+        low = int(np.searchsorted(timestamps, window_start_ms, side="left"))
+        high = int(np.searchsorted(timestamps, window_end_ms, side="right"))
+        session.seed_charger_series(timestamps[low:high], values[low:high])
 
     async def load_summary(self, start_ms: int, end_ms: int) -> dict | None:
         '''
@@ -270,7 +306,10 @@ class ChargingLoader:
         '''
         if end_ms <= start_ms:
             return None
-        session = ChargingSession(self.__influx, start_ms, end_ms)
+        session = ChargingSession(
+            self.__influx, start_ms, end_ms,
+            spot_provider=self.__spot_provider, flat_tariff=self.__flat_tariff,
+        )
         return await session.summary()
 
     async def get_power_history(self, data_property_id: str, time_start: str, time_end: str):
@@ -299,16 +338,18 @@ class ChargingLoader:
         session's summary()), so charger vs car energy stay apples-to-apples over the same
         session set. Distance and driving energy are the tesla lifetime counters' month
         deltas (Odometer / LifetimeEnergyUsed, the same first-of-month baseline
-        DrivenThisMonth uses); the home grid import is the month integral of positive
-        GridPower. Every field degrades to NaN when its source is missing, so a partial-
-        data month still yields a well-formed record. Cost is added by the request handler
-        (it owns the tariff).
+        DrivenThisMonth uses); the home grid import is the per-hour integral of positive
+        GridPower, summed. Both cost fields are computed here (the loader owns the spot
+        provider + flat tariff): charging_cost_eur = Σ per-session spot-priced cost;
+        home_cost_eur = Σ hour_kwh × that hour's spot price. Every field degrades to NaN
+        when its source is missing, so a partial-data month still yields a well-formed record.
         Arguments:
             start_ms (int): Month start (1st, 00:00 local), epoch-ms UTC.
             end_ms (int): Now, epoch-ms UTC.
         Returns:
             dict: The month aggregate (energy, waste, efficiency, consumption/km,
-                sessions, charge time, home import), each value a float (may be NaN).
+                sessions, charge time, cost, home import + cost), each value a float
+                (may be NaN).
         '''
         sessions = await self.list_sessions(start_ms, end_ms)
 
@@ -316,6 +357,8 @@ class ChargingLoader:
         battery_sum = 0.0
         battery_count = 0
         charge_time_s = 0.0
+        cost_sum = 0.0
+        cost_count = 0
         for session in sessions:
             summary = await session.summary()
             # list_sessions already dropped NaN-charger sessions, so charger_kwh is real.
@@ -325,6 +368,13 @@ class ChargingLoader:
                 battery_sum += battery_kwh
                 battery_count += 1
             charge_time_s += summary["duration_s"]
+            # Month charging cost = Σ per-session spot-priced cost (each session already
+            # priced its energy per hour). A NaN session cost (unpriceable) is skipped so
+            # one gap doesn't void the month, matching how car_kwh handles missing battery.
+            session_cost = summary["cost_eur"]
+            if not math.isnan(session_cost):
+                cost_sum += session_cost
+                cost_count += 1
 
         session_count = len(sessions)
         charger_kwh = charger_sum if session_count > 0 else float("nan")
@@ -356,16 +406,32 @@ class ChargingLoader:
             else float("nan")
         )
 
-        home_grid_kwh = await self.__influx.read_grid_import_kwh_month()
-        if home_grid_kwh is None:
+        charging_cost_eur = cost_sum if cost_count > 0 else float("nan")
+
+        # Whole-home grid import + its cost, priced per UTC hour. One hourly read yields
+        # both the total (Σ hours) and the cost (Σ hour_kwh × that hour's spot price, per-
+        # hour flat-tariff fallback) — no separate month integral.
+        hourly_home = await self.__influx.read_grid_import_kwh_hourly(start_ms, end_ms)
+        if hourly_home:
+            home_grid_kwh = float(sum(hourly_home.values()))
+            home_prices: dict = {}
+            if self.__spot_provider is not None and self.__spot_provider.enabled:
+                home_prices = await self.__spot_provider.prices_for_range(start_ms, end_ms)
+            home_cost_eur = price_hourly_energy(hourly_home, home_prices, self.__flat_tariff)
+        else:
             home_grid_kwh = float("nan")
+            home_cost_eur = float("nan")
 
         logger.info(
-            "Month charging summary: sessions=%d charger=%s kWh car=%s kWh eff=%s%%",
+            "Month charging summary: sessions=%d charger=%s kWh car=%s kWh eff=%s%% "
+            "charging_cost=%s home=%s kWh home_cost=%s",
             session_count,
             "n/a" if math.isnan(charger_kwh) else f"{charger_kwh:.2f}",
             "n/a" if math.isnan(car_kwh) else f"{car_kwh:.2f}",
             "n/a" if math.isnan(efficiency_pct) else f"{efficiency_pct:.1f}",
+            "n/a" if math.isnan(charging_cost_eur) else f"{charging_cost_eur:.2f}€",
+            "n/a" if math.isnan(home_grid_kwh) else f"{home_grid_kwh:.1f}",
+            "n/a" if math.isnan(home_cost_eur) else f"{home_cost_eur:.2f}€",
         )
         return {
             "charger_kwh": charger_kwh,
@@ -378,7 +444,9 @@ class ChargingLoader:
             "km_month": km_month,
             "session_count": float(session_count),
             "total_charge_s": charge_time_s,
+            "charging_cost_eur": charging_cost_eur,
             "home_grid_kwh": home_grid_kwh,
+            "home_cost_eur": home_cost_eur,
         }
 
     async def __month_delta(self, data_property_id: str, now_iso: str) -> float:

--- a/backend/src/charging_service/charging_session.py
+++ b/backend/src/charging_service/charging_session.py
@@ -32,7 +32,11 @@ from datetime import datetime, timezone
 
 import numpy as np
 
+from .spot_price import price_hourly_energy
+
 logger = logging.getLogger("charging_service.charging_session")
+
+_HOUR_MS = 3_600_000
 
 # InfluxDB "id" tags this module reads. The charger ids are written by
 # MyEnergiService under the "myenergi_data" measurement; the tesla ids are logged by
@@ -95,6 +99,34 @@ def _positive_increment(result) -> float:
     return float(np.clip(np.diff(values), 0.0, None).sum())
 
 
+def bucket_positive_increments_by_hour(timestamps_ms, values) -> dict:
+    '''
+    Buckets an accumulator series' positive increments (kWh) by the UTC hour they fell in —
+    the per-hour version of _positive_increment, so charging energy can be priced against
+    each hour's spot price. Each increment (ChargeAdded step between two samples) is
+    attributed to the UTC hour of the *later* sample; since ChargeAdded is logged ~10 s
+    apart while charging, an interval almost never straddles an hour boundary, so no
+    sub-step splitting is needed. Pure/testable: no I/O. Fewer than two samples -> {}.
+    Arguments:
+        timestamps_ms: Ascending epoch-ms sample times (int64 array/sequence).
+        values: The accumulator value (kWh) at each sample, same length.
+    Returns:
+        dict: {utc_hour_start_ms: energy_kwh} — only hours with delivered energy appear.
+    '''
+    if timestamps_ms is None or values is None or len(timestamps_ms) < 2:
+        return {}
+    ts = np.asarray(timestamps_ms, dtype=np.int64)
+    vals = np.asarray(values, dtype=np.float64)
+    increments = np.clip(np.diff(vals), 0.0, None)
+    hours = (ts[1:] // _HOUR_MS) * _HOUR_MS
+    result: dict[int, float] = {}
+    for hour, increment in zip(hours, increments):
+        if increment > 0.0:
+            key = int(hour)
+            result[key] = result.get(key, 0.0) + float(increment)
+    return result
+
+
 def _first(result) -> float:
     '''First value of a series, or NaN if empty/missing.'''
     values = _series_values(result)
@@ -130,15 +162,30 @@ class ChargingSession:
             session still in progress), epoch-ms UTC.
         in_progress (bool): True if the car was still charging at the query-window end
             (no stop observed yet).
+        spot_provider (SpotPriceProvider | None): Supplies the hourly Nord Pool spot price
+            for the session's cost estimate. None (or a disabled provider) -> cost falls
+            back to flat_tariff, or NaN if that is also None.
+        flat_tariff (float | None): Flat €/kWh fallback used for any hour with no spot
+            price (and the whole cost when spot pricing is off). None -> unpriced hours are
+            uncounted.
     '''
 
-    def __init__(self, influx_handler, start_ms: int, end_ms: int, in_progress: bool = False):
+    def __init__(
+        self, influx_handler, start_ms: int, end_ms: int, in_progress: bool = False,
+        spot_provider=None, flat_tariff: float | None = None,
+    ):
         self.__influx = influx_handler
         self.__start_ms = int(start_ms)
         self.__end_ms = int(end_ms)
         self.__in_progress = in_progress
+        self.__spot_provider = spot_provider
+        self.__flat_tariff = flat_tariff
         self.__summary: dict | None = None
         self.__charger_kwh: float | None = None
+        # Optional (timestamps_ms, values) of the window's ChargeAdded series, seeded by
+        # ChargingLoader from its single bulk read so the cost path buckets by hour without
+        # a re-read. None -> summary() reads the series itself (the single-session path).
+        self.__charger_series: tuple | None = None
 
     @property
     def session_id(self) -> int:
@@ -160,13 +207,69 @@ class ChargingSession:
     def seed_charger_kwh(self, value: float) -> None:
         '''
         Seeds the cached charger energy from a value computed elsewhere (ChargingLoader
-        reads the whole span's ChargeAdded once and takes each window's in-memory max),
-        so charger_kwh()/summary() don't re-read it per session. NaN when the window
-        held no charger sample (a session at another charger).
+        reads the whole span's ChargeAdded once and sums each window's positive
+        increments), so charger_kwh()/summary() don't re-read it per session. NaN when the
+        window held no charger sample (a session at another charger).
         Arguments:
             value (float): The session's delivered energy in kWh (may be NaN).
         '''
         self.__charger_kwh = value
+
+    def seed_charger_series(self, timestamps_ms, values) -> None:
+        '''
+        Seeds the window's raw ChargeAdded series (already sliced out of ChargingLoader's
+        single bulk read) so summary()'s cost path can bucket delivered energy by hour
+        without a second query. Optional — the single-session detail path leaves it unset
+        and summary() reads the series itself.
+        Arguments:
+            timestamps_ms: Ascending epoch-ms sample times for this window.
+            values: The ChargeAdded accumulator value (kWh) at each sample.
+        '''
+        self.__charger_series = (timestamps_ms, values)
+
+    async def __hourly_charger_kwh(self) -> dict:
+        '''
+        Returns the session's delivered energy bucketed by UTC hour ({hour_ms: kWh}) for
+        the spot-price cost path. Uses the seeded window series when present (the month
+        path), else reads the ChargeAdded series for the window once (the detail path).
+        Empty when no charger data covers the window.
+        '''
+        if self.__charger_series is not None:
+            timestamps_ms, values = self.__charger_series
+        else:
+            result = await self.__influx.read_charger_data_property(
+                CHARGER_ENERGY_ID, to_flux_time(self.__start_ms), to_flux_time(self.__end_ms)
+            )
+            if result is None:
+                return {}
+            _count, timestamps_ms, values = result
+        return bucket_positive_increments_by_hour(timestamps_ms, values)
+
+    async def __cost(self, charger_kwh: float) -> tuple:
+        '''
+        Computes (cost_eur, avg_price_eur_per_kwh) for the session: its delivered energy
+        bucketed by UTC hour, each hour priced at that hour's all-in spot price, with a
+        per-hour fallback to the flat tariff. cost is NaN when neither a spot price nor a
+        flat tariff can price any hour; avg price is cost / delivered energy.
+        Arguments:
+            charger_kwh (float): The session's total delivered energy (for the average).
+        '''
+        provider = self.__spot_provider
+        spot_active = provider is not None and provider.enabled
+        if not spot_active and self.__flat_tariff is None:
+            # Nothing can price this session — skip the extra read entirely.
+            return float("nan"), float("nan")
+        hourly = await self.__hourly_charger_kwh()
+        prices: dict = {}
+        if provider is not None and provider.enabled:
+            prices = await provider.prices_for_range(self.__start_ms, self.__end_ms)
+        cost_eur = price_hourly_energy(hourly, prices, self.__flat_tariff)
+        avg_price = (
+            cost_eur / charger_kwh
+            if (not math.isnan(cost_eur) and not math.isnan(charger_kwh) and charger_kwh > 0)
+            else float("nan")
+        )
+        return cost_eur, avg_price
 
     async def charger_kwh(self) -> float:
         '''
@@ -190,12 +293,14 @@ class ChargingSession:
 
     async def summary(self) -> dict:
         '''
-        Computes (and caches) the session's loss breakdown. Charger energy is the
-        in-window max of the myenergi accumulator; AC-in / DC-in / battery energies are
-        deltas of the vehicle's in-window series; SoC is read at the window endpoints.
-        Losses are simple differences, each NaN if either operand is missing — so a
-        session with no charger data (charged elsewhere) reports NaN losses rather than
-        a fabricated number. duration is wall-clock (start to end).
+        Computes (and caches) the session's loss breakdown and cost. Charger energy is the
+        sum of the myenergi accumulator's positive increments in the window; AC-in / DC-in
+        / battery energies are deltas of the vehicle's in-window series; SoC is read at the
+        window endpoints. Losses are simple differences, each NaN if either operand is
+        missing — so a session with no charger data (charged elsewhere) reports NaN losses
+        rather than a fabricated number. cost_eur prices the delivered energy per UTC hour
+        against the hourly spot price (falling back to the flat tariff); avg_price_eur_per_kwh
+        is cost / delivered energy. duration is wall-clock (start to end).
         '''
         if self.__summary is not None:
             return self.__summary
@@ -223,6 +328,8 @@ class ChargingSession:
             else float("nan")
         )
 
+        cost_eur, avg_price_eur_per_kwh = await self.__cost(charger_kwh)
+
         self.__summary = {
             "session_id": self.__start_ms,
             "start_ms": self.__start_ms,
@@ -238,6 +345,8 @@ class ChargingSession:
             "loss_total_pct": loss_total_pct,
             "start_soc": _first(soc),
             "end_soc": _last(soc),
+            "cost_eur": cost_eur,
+            "avg_price_eur_per_kwh": avg_price_eur_per_kwh,
             "in_progress": self.__in_progress,
         }
         logger.debug(

--- a/backend/src/charging_service/spot_price.py
+++ b/backend/src/charging_service/spot_price.py
@@ -1,0 +1,241 @@
+'''
+SpotPriceProvider — Nord Pool FI spot electricity price, fetched on demand (issue #12).
+
+The Charging view prices energy against the actual hourly Nord Pool spot price for the hour
+each kWh was drawn, instead of a single flat tariff. Prices come from a free no-key Finnish
+API (sähkötin.fi), which serves *historical* hourly FI-zone prices — so a charging session
+from days/weeks ago can be priced retroactively without us logging prices ourselves.
+
+This module is the shared pricing core: it fetches, caches, and converts prices. Two consumers
+use it — the on-demand ChargingSession / ChargingLoader (per-session + month cost) and the
+always-on SpotPriceService (the live current-price tile). It owns no protocol/serialization.
+
+Correctness model:
+  - Every price and every energy bucket is keyed by UTC hour-start ms. Nord Pool hours are
+    fixed UTC instants; keying by UTC (never local wall-clock) keeps the two DST switch days
+    (23h/25h) correct.
+  - The API returns raw wholesale €/MWh. The all-in estimate the tiles use is
+    (spot_€/kWh + margin_€/kWh) * (1 + VAT). VAT and margin come from config.spot_price_config.
+  - Past hours are immutable, so once fetched a raw price is cached for the process lifetime.
+    The VAT/margin conversion is applied on read, so a config change never needs a cache flush.
+'''
+import asyncio
+import logging
+import math
+from datetime import datetime, timezone
+
+import aiohttp
+
+logger = logging.getLogger("charging_service.spot_price")
+
+_HOUR_MS = 3_600_000
+_FETCH_TIMEOUT = aiohttp.ClientTimeout(total=15)
+
+
+def _hour_floor_ms(timestamp_ms: int) -> int:
+    '''Floors an epoch-ms instant to the start of its UTC hour (epoch-ms).'''
+    return (int(timestamp_ms) // _HOUR_MS) * _HOUR_MS
+
+
+def _to_iso_z(timestamp_ms: int) -> str:
+    '''Epoch-ms -> the RFC3339 'Z' string sähkötin expects for its start/end params.'''
+    return (
+        datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _parse_iso_z(value: str) -> int:
+    '''
+    Parses an RFC3339 'Z' timestamp (e.g. "2026-07-07T00:00:00.000Z") to epoch-ms.
+    Arguments:
+        value (str): The ISO-8601 UTC timestamp from a price entry's "date" field.
+    '''
+    dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    return int(dt.timestamp() * 1000)
+
+
+def price_hourly_energy(
+    hourly_kwh: dict[int, float],
+    prices: dict[int, float],
+    flat_fallback: float | None = None,
+) -> float:
+    '''
+    Costs a per-UTC-hour energy map against a per-hour all-in price map, falling back to a
+    flat €/kWh tariff for any hour with no spot price. This is the single place the
+    energy×price dot-product lives, shared by the per-session and month cost paths.
+    Returns the total € cost, or NaN when nothing could be priced (no spot price for any
+    hour and no flat fallback). An hour whose energy has neither a spot price nor a flat
+    fallback is dropped (its energy goes uncounted) rather than voiding the whole total.
+    Arguments:
+        hourly_kwh (dict[int, float]): {utc_hour_start_ms: energy_kwh}. NaN energy skipped.
+        prices (dict[int, float]): {utc_hour_start_ms: all_in_eur_per_kwh}.
+        flat_fallback (float | None): Flat €/kWh used when an hour has no spot price, or None.
+    '''
+    total = 0.0
+    priced_any = False
+    for hour, kwh in hourly_kwh.items():
+        if kwh is None or math.isnan(kwh):
+            continue
+        price = prices.get(hour)
+        if price is None:
+            price = flat_fallback
+        if price is None:
+            continue
+        total += kwh * price
+        priced_any = True
+    return total if priced_any else float("nan")
+
+
+class SpotPriceProvider:
+    '''
+    Fetches, caches, and converts Nord Pool FI spot prices.
+
+    Constructed unconditionally (independent of the myenergi charger — the live price tile
+    should show even with no Zappi). When spot_price_config["enabled"] is false every method
+    degrades to "no price", so callers fall back to the flat tariff.
+    Arguments:
+        config (Config): Shared configuration; spot_price_config supplies enabled, vatPercent,
+            marginCentsPerKwh, and baseUrl.
+    '''
+
+    def __init__(self, config):
+        cfg = config.spot_price_config
+        self.__enabled = bool(cfg["enabled"])
+        self.__base_url = str(cfg["baseUrl"])
+        self.__vat_multiplier = 1.0 + float(cfg["vatPercent"]) / 100.0
+        self.__margin_eur_per_kwh = float(cfg["marginCentsPerKwh"]) / 100.0
+        # UTC-hour-start ms -> raw spot €/kWh (no VAT/margin). Past hours are immutable, so a
+        # cache hit is never re-fetched; the all-in conversion is applied on read.
+        self.__raw_cache: dict[int, float] = {}
+
+    @property
+    def enabled(self) -> bool:
+        '''True when spot pricing is switched on in config.'''
+        return self.__enabled
+
+    def _all_in(self, raw_eur_per_kwh: float) -> float:
+        '''Applies seller margin then VAT to a raw wholesale €/kWh price.'''
+        return (raw_eur_per_kwh + self.__margin_eur_per_kwh) * self.__vat_multiplier
+
+    async def prices_for_range(self, start_ms: int, end_ms: int) -> dict[int, float]:
+        '''
+        Returns {utc_hour_start_ms: all_in_eur_per_kwh} for every whole UTC hour the window
+        [start_ms, end_ms] touches (inclusive of the hour containing end). Empty when spot
+        pricing is disabled, the window is inverted, or the fetch yields nothing. Fetches
+        the span (once) only if some hour is not already cached.
+        Arguments:
+            start_ms (int): Window start, epoch-ms UTC.
+            end_ms (int): Window end, epoch-ms UTC.
+        '''
+        if not self.__enabled or end_ms <= start_ms:
+            return {}
+        first = _hour_floor_ms(start_ms)
+        last = _hour_floor_ms(end_ms - 1)
+        await self.__ensure_cached(first, last)
+        result: dict[int, float] = {}
+        hour = first
+        while hour <= last:
+            raw = self.__raw_cache.get(hour)
+            if raw is not None:
+                result[hour] = self._all_in(raw)
+            hour += _HOUR_MS
+        return result
+
+    async def price_at(self, timestamp_ms: int) -> float | None:
+        '''
+        Returns the all-in €/kWh price for the hour containing timestamp_ms, or None when
+        pricing is disabled or the hour has no price. Fetches the hour if not cached.
+        Arguments:
+            timestamp_ms (int): The instant to price, epoch-ms UTC.
+        '''
+        if not self.__enabled:
+            return None
+        hour = _hour_floor_ms(timestamp_ms)
+        await self.__ensure_cached(hour, hour)
+        raw = self.__raw_cache.get(hour)
+        return self._all_in(raw) if raw is not None else None
+
+    def raw_price_at(self, timestamp_ms: int) -> float | None:
+        '''
+        Returns the cached *raw* (no VAT/margin) €/kWh for the hour containing timestamp_ms
+        without fetching, or None if not cached. Used by the live broadcast, which pairs the
+        raw wholesale price with the all-in estimate.
+        Arguments:
+            timestamp_ms (int): The instant to look up, epoch-ms UTC.
+        '''
+        return self.__raw_cache.get(_hour_floor_ms(timestamp_ms))
+
+    async def __ensure_cached(self, first_hour_ms: int, last_hour_ms: int) -> None:
+        '''
+        Ensures every whole UTC hour in [first_hour_ms, last_hour_ms] is present in the
+        cache, fetching the whole span in one request when any hour is missing. A fully
+        cached span (all past hours) skips the network entirely; a span with an unpublished
+        or not-yet-fetched hour (today/tomorrow) triggers one fetch.
+        Arguments:
+            first_hour_ms (int): First UTC hour-start to cover, epoch-ms.
+            last_hour_ms (int): Last UTC hour-start to cover (inclusive), epoch-ms.
+        '''
+        missing = any(
+            h not in self.__raw_cache
+            for h in range(first_hour_ms, last_hour_ms + _HOUR_MS, _HOUR_MS)
+        )
+        if not missing:
+            return
+        await self.__fetch_and_cache(first_hour_ms, last_hour_ms + _HOUR_MS)
+
+    async def __fetch_and_cache(self, start_ms: int, end_ms: int) -> None:
+        '''
+        Fetches sähkötin's price range for [start_ms, end_ms) and merges it into the cache.
+        Network/decoding failures are logged and swallowed — the caller then prices with
+        whatever is already cached (possibly nothing), never crashing the request.
+        Arguments:
+            start_ms (int): Fetch window start, epoch-ms UTC.
+            end_ms (int): Fetch window end (exclusive), epoch-ms UTC.
+        '''
+        params = {"start": _to_iso_z(start_ms), "end": _to_iso_z(end_ms)}
+        try:
+            async with aiohttp.ClientSession(timeout=_FETCH_TIMEOUT) as session:
+                async with session.get(self.__base_url, params=params) as resp:
+                    resp.raise_for_status()
+                    # sähkötin serves JSON without a JSON content-type on some paths;
+                    # content_type=None disables aiohttp's strict mimetype check.
+                    data = await resp.json(content_type=None)
+        except (aiohttp.ClientError, asyncio.TimeoutError, ValueError) as e:
+            logger.warning(
+                "Spot price fetch failed for %s..%s: %s: %s",
+                params["start"], params["end"], type(e).__name__, e,
+            )
+            return
+        self.__ingest(data)
+
+    def __ingest(self, data) -> None:
+        '''
+        Merges a sähkötin response ({"prices": [{"date": "…Z", "value": €/MWh}, …]}) into
+        the cache. Each entry is floored to its UTC hour and, if several entries share an
+        hour (a 15-minute-resolution response), averaged — so the cache always holds one
+        raw €/kWh per hour regardless of the API's resolution.
+        Arguments:
+            data: The decoded JSON body (expected dict with a "prices" list).
+        '''
+        prices = data.get("prices") if isinstance(data, dict) else None
+        if not prices:
+            logger.debug("Spot price response carried no 'prices' array")
+            return
+        sums: dict[int, float] = {}
+        counts: dict[int, int] = {}
+        for entry in prices:
+            try:
+                hour = _hour_floor_ms(_parse_iso_z(entry["date"]))
+                eur_per_mwh = float(entry["value"])
+            except (KeyError, TypeError, ValueError):
+                continue
+            if math.isnan(eur_per_mwh):
+                continue
+            sums[hour] = sums.get(hour, 0.0) + eur_per_mwh
+            counts[hour] = counts.get(hour, 0) + 1
+        for hour, total in sums.items():
+            self.__raw_cache[hour] = (total / counts[hour]) / 1000.0  # €/MWh -> €/kWh
+        if sums:
+            logger.info("Cached %d hourly spot prices", len(sums))

--- a/backend/src/charging_service/spot_price_service.py
+++ b/backend/src/charging_service/spot_price_service.py
@@ -1,0 +1,124 @@
+'''
+SpotPriceService — broadcasts the live Nord Pool spot price for the Charging view's
+current-price tile (issue #12).
+
+A thin always-on wrapper around the shared SpotPriceProvider: it fetches the current hour's
+price and re-broadcasts it once per hour as a SPOT_PRICE_STREAM frame, and replays the last
+frame to any newly connected client. Structurally identical to WeatherService (initial fetch
++ APScheduler job + last-frame cache for stream_everything), just with a one-hour cadence —
+Nord Pool prices are hourly, so there is nothing finer to show.
+
+It is independent of the myenergi charger (constructed and run unconditionally) so the price
+tile works even with no Zappi. When spot pricing is disabled in config, run() returns without
+scheduling anything and no frame is ever cached, so the tile simply stays empty.
+'''
+import asyncio
+import logging
+import struct
+from datetime import datetime, timezone
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from ..server.server import Server
+from ..utils import protocol
+from ..utils.config_parser import Config
+from .spot_price import SpotPriceProvider
+
+logger = logging.getLogger("charging_service.spot_price_service")
+
+_HOUR_MS = 3_600_000
+
+
+def _build_spot_price_frame(hour_start_ms: int, spot_eur_per_kwh, all_in_eur_per_kwh) -> bytes:
+    '''
+    Builds a SPOT_PRICE_STREAM frame. status is 0 (no price) when all_in is None — the
+    fixed field block is still written (NaN-filled) so the client parses a constant size —
+    else 1. spot is the raw wholesale €/kWh, all_in the VAT+margin estimate the tiles use.
+    Arguments:
+        hour_start_ms (int): UTC start of the priced hour, epoch-ms.
+        spot_eur_per_kwh (float | None): Raw wholesale price, or None.
+        all_in_eur_per_kwh (float | None): All-in estimate, or None when unavailable.
+    '''
+    status = 0 if all_in_eur_per_kwh is None else 1
+    spot = float("nan") if spot_eur_per_kwh is None else float(spot_eur_per_kwh)
+    all_in = float("nan") if all_in_eur_per_kwh is None else float(all_in_eur_per_kwh)
+    body = struct.pack("!B", status)
+    body += struct.pack("!q", int(hour_start_ms))
+    body += struct.pack("!d", spot)
+    body += struct.pack("!d", all_in)
+    return protocol.frame(protocol.SPOT_PRICE_STREAM, body)
+
+
+class SpotPriceService:
+    '''
+    Fetches and broadcasts the live hourly spot price.
+    Arguments:
+        server (Server): TCP server used to broadcast + snapshot the price frame.
+        config (Config): Shared configuration (timezone for the scheduler).
+        provider (SpotPriceProvider): The shared fetch/cache/convert core (also used by the
+            on-demand charging cost path).
+    '''
+
+    def __init__(self, server: Server, config: Config, provider: SpotPriceProvider):
+        self.__server = server
+        self.__provider = provider
+        self.__zone_info = config.zone_info
+        self.__scheduler = AsyncIOScheduler(timezone=self.__zone_info)
+        # Most recent framed price packet, replayed verbatim to a newly connected client so
+        # its price tile populates immediately without waiting for the next hourly tick.
+        self.__last_frame: bytes | None = None
+
+    async def run(self) -> None:
+        '''
+        Starts the service: pre-warms today+tomorrow's prices, broadcasts the current hour,
+        then re-broadcasts every hour on the hour. A no-op when spot pricing is disabled.
+        '''
+        if not self.__provider.enabled:
+            logger.info("Spot pricing disabled; live price service not started")
+            return
+        logger.info("Spot price service starting")
+        # Pre-warm a today+tomorrow window so the hourly broadcasts (and the on-demand cost
+        # path) mostly hit the cache; tomorrow's prices publish early afternoon.
+        now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+        hour_ms = (now_ms // _HOUR_MS) * _HOUR_MS
+        await self.__provider.prices_for_range(hour_ms, hour_ms + 47 * _HOUR_MS)
+        await self.__broadcast_current()
+        self.__scheduler.start()
+        self.__scheduler.add_job(
+            func=self.__broadcast_current,
+            trigger=CronTrigger(minute=0, timezone=self.__zone_info),
+        )
+
+    def get_run_task(self) -> asyncio.Task:
+        '''Returns an asyncio Task that starts the spot price service.'''
+        return asyncio.create_task(self.run())
+
+    async def __broadcast_current(self) -> None:
+        '''
+        Fetches the current hour's all-in price (raw price paired from cache) and broadcasts
+        it to all clients, caching the frame for stream_everything. On a fetch miss (API
+        down / unpublished hour) a status=0 frame is broadcast so the tile can show "—"
+        rather than a stale value.
+        '''
+        now_ms = int(datetime.now(timezone.utc).timestamp() * 1000)
+        hour_ms = (now_ms // _HOUR_MS) * _HOUR_MS
+        all_in = await self.__provider.price_at(now_ms)
+        spot = self.__provider.raw_price_at(now_ms)
+        self.__last_frame = _build_spot_price_frame(hour_ms, spot, all_in)
+        logger.info(
+            "Broadcasting spot price: hour=%s all_in=%s €/kWh",
+            datetime.fromtimestamp(hour_ms / 1000, tz=timezone.utc).isoformat(),
+            "n/a" if all_in is None else f"{all_in:.4f}",
+        )
+        await self.__server.broadcast(self.__last_frame)
+
+    async def stream_everything(self, client) -> None:
+        '''
+        Sends the most recent cached price frame to a newly connected client. No-op until
+        the first broadcast (or when spot pricing is disabled).
+        Arguments:
+            client: StreamWriter for the new connection.
+        '''
+        if self.__last_frame is not None:
+            await self.__server.send_to(client, self.__last_frame)

--- a/backend/src/influxdb_service/influxdb_handler.py
+++ b/backend/src/influxdb_service/influxdb_handler.py
@@ -2,7 +2,7 @@ from influxdb_client.client.influxdb_client_async import InfluxDBClientAsync
 import logging
 import re
 import numpy as np
-from datetime import datetime
+from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 from ..utils.config_parser import get_env
 
@@ -12,7 +12,58 @@ _SAFE_ID = re.compile(r'^[A-Za-z0-9_\-]+$')
 # 5m, 1h, 30d).
 _SAFE_WINDOW = re.compile(r'^[1-9][0-9]*[smhd]$')
 
+_HOUR_MS = 3_600_000
+
 logger = logging.getLogger("influxdb_service.influxdb_handler")
+
+
+def _ms_to_flux_z(timestamp_ms: int) -> str:
+    '''Epoch-ms -> the RFC3339 'Z' string a Flux range() accepts.'''
+    return (
+        datetime.fromtimestamp(timestamp_ms / 1000, tz=timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def integrate_power_series_hourly(timestamps_ms, values) -> dict:
+    '''
+    Trapezoidally integrates a power (W) time series into energy (kWh) bucketed by UTC hour.
+    Each sample interval is split at hour boundaries and the (linearly interpolated) power
+    at each slice's endpoints is trapezoided, so energy lands in the hour it was actually
+    drawn — the per-hour analogue of Flux integral(unit: 1h). Negative power (grid export)
+    is clamped to zero first, so only imported energy ("energy bought") is counted. Pure/
+    testable: no I/O. Fewer than two samples -> {}.
+    Arguments:
+        timestamps_ms: Ascending epoch-ms sample times (int64 array/sequence).
+        values: Power in W at each sample (float array/sequence), same length.
+    Returns:
+        dict: {utc_hour_start_ms: energy_kwh} for every hour the series spans.
+    '''
+    ts = np.asarray(timestamps_ms, dtype=np.int64)
+    clamped = np.clip(np.asarray(values, dtype=np.float64), 0.0, None)
+    n = len(ts)
+    result: dict[int, float] = {}
+    for i in range(n - 1):
+        t0 = int(ts[i])
+        t1 = int(ts[i + 1])
+        if t1 <= t0:
+            continue
+        p0 = float(clamped[i])
+        p1 = float(clamped[i + 1])
+        span = t1 - t0
+        a = t0
+        while a < t1:
+            hour = (a // _HOUR_MS) * _HOUR_MS
+            b = min(t1, hour + _HOUR_MS)
+            # Power linearly interpolated at the slice endpoints, then trapezoided
+            # (exact for a linear segment). W * (ms / 3.6e6) -> Wh; /1000 -> kWh.
+            pa = p0 + (p1 - p0) * (a - t0) / span
+            pb = p0 + (p1 - p0) * (b - t0) / span
+            wh = (pa + pb) / 2.0 * (b - a) / _HOUR_MS
+            result[hour] = result.get(hour, 0.0) + wh / 1000.0
+            a = b
+    return result
 
 
 class InfluxDBHandler:
@@ -174,6 +225,33 @@ class InfluxDBHandler:
         values = np.array([record.get_value() for record in records], dtype=np.float64)
 
         return len(values), timestamps, values
+
+    async def read_grid_import_kwh_hourly(self, start_ms: int, end_ms: int) -> dict | None:
+        '''
+        Reads the logged grid power (myenergi "GridPower", W) over [start_ms, end_ms] and
+        integrates it into imported energy (kWh) bucketed by UTC hour — the per-hour input
+        the spot-price cost path needs (each hour's kWh × that hour's price). Reuses the
+        raw read_charger_data_property("GridPower", …) read and integrates in Python
+        (integrate_power_series_hourly), rather than a Flux windowed integral(): it reuses
+        the existing safe read and keeps the bucketing unit-testable. Only import (positive
+        power) is counted, so grid export doesn't subtract. The month total is just
+        sum(result.values()). Degrades to None on an unreachable/failed query or a window
+        with fewer than two samples.
+        Arguments:
+            start_ms (int): Window start, epoch-ms UTC.
+            end_ms (int): Window end, epoch-ms UTC.
+        Returns:
+            dict | None: {utc_hour_start_ms: kwh}, or None.
+        '''
+        result = await self.read_charger_data_property(
+            "GridPower", _ms_to_flux_z(start_ms), _ms_to_flux_z(end_ms)
+        )
+        if result is None:
+            return None
+        count, timestamps, values = result
+        if count < 2:
+            return None
+        return integrate_power_series_hourly(timestamps, values)
 
     async def read_last_value_before(
         self, data_property_id: str, stop_time: str
@@ -568,54 +646,3 @@ class InfluxDBHandler:
         value = table.records[0].get_value()
         logger.debug("First value of month for %s: %s", data_property_id, value)
         return value
-
-    async def read_grid_import_kwh_month(self) -> float | None:
-        '''
-        Integrates the logged grid power (myenergi "GridPower", W) over the current
-        calendar month (from the 1st, 00:00 in the configured timezone) into energy (kWh),
-        counting only import (positive power) so grid export does not subtract from
-        "energy bought" — the Charging view's month-to-date home grid-import figure. Uses
-        Flux integral(unit: 1h) (W integrated over hours -> Wh), converted to kWh. Relies
-        on GridPower being logged every poll (MyEnergiService), so the integral has a dense
-        series to trapezoid over. Degrades to None on an unreachable/failed query or a
-        month with no samples yet, matching the other reads' contract.
-        Returns:
-            float | None: Imported energy this month in kWh, or None.
-        '''
-        month_start = datetime.now(self.__timezone).replace(
-            day=1, hour=0, minute=0, second=0, microsecond=0
-        ).isoformat()
-
-        # "GridPower" is a fixed literal id (not caller input), so no _SAFE_ID needed.
-        query = f'from(bucket:"{self.__bucket}")'
-        query += f'\n  |> range(start: {month_start})'
-        query += '\n  |> filter(fn: (r) => r["_measurement"] == "myenergi_data")'
-        query += '\n  |> filter(fn: (r) => r["id"] == "GridPower")'
-        query += '\n  |> filter(fn: (r) => r["_field"] == "value_float")'
-        query += '\n  |> sort(columns: ["_time"])'
-        # Clamp export (negative) to zero so only imported energy is counted, then
-        # integrate W over hours to get Wh. NOTE: integral() requires the range's _start
-        # column to stay in the group key, so we must NOT keep()-drop the columns before
-        # integrating (doing so fails with "integral needs _start column").
-        query += '\n  |> map(fn: (r) => ({ r with _value: if r._value < 0.0 then 0.0 else r._value }))'
-        query += '\n  |> integral(unit: 1h)'
-
-        try:
-            result = await self.__client.query_api().query(query=query)
-        except Exception as e:
-            logger.warning(
-                "InfluxDB grid-import-month read failed: %s: %s", type(e).__name__, e
-            )
-            return None
-
-        if len(result) == 0:
-            return None
-
-        table = result[0]
-        if not table.records:
-            return None
-
-        value = table.records[0].get_value()
-        if value is None:
-            return None
-        return float(value) / 1000.0  # Wh -> kWh

--- a/backend/src/start_services.py
+++ b/backend/src/start_services.py
@@ -1,11 +1,12 @@
 import asyncio
 import logging
-import math
 import os
 import struct
 from datetime import datetime, timezone
 
 from .charging_service.charging_loader import ChargingLoader
+from .charging_service.spot_price import SpotPriceProvider
+from .charging_service.spot_price_service import SpotPriceService
 from .influxdb_service.influxdb_handler import InfluxDBHandler
 from .media_service.media_manager import MediaManager
 from .myenergi_service.myenergi_service import MyEnergiService
@@ -250,11 +251,13 @@ def _build_trip_series_frame(trip_id: int, data_property_id: str, result) -> byt
 
 # The charging-loss summary fields packed (in order) after the echoed
 # session_id/status/window. Every value is an IEEE-754 double; a missing metric packs
-# as NaN, which the frontend renders as "—". Mirrors _TRIP_SUMMARY_FIELDS.
+# as NaN, which the frontend renders as "—". Mirrors _TRIP_SUMMARY_FIELDS. cost_eur /
+# avg_price_eur_per_kwh are the session's spot-priced cost + its average €/kWh (NaN when
+# spot pricing is off and no flat tariff is set).
 _CHARGING_SUMMARY_FIELDS = (
     "charger_kwh", "ac_in_kwh", "battery_kwh",
     "loss_cable_kwh", "loss_conversion_kwh", "loss_total_kwh", "loss_total_pct",
-    "start_soc", "end_soc",
+    "start_soc", "end_soc", "cost_eur", "avg_price_eur_per_kwh",
 )
 
 
@@ -623,11 +626,12 @@ def _register_handlers(
     async def _get_charging_month(_payload: bytes, writer) -> None:
         '''
         Computes the month-to-date charging aggregate (energy, waste, efficiency,
-        consumption/km, sessions, cost, home import) and replies to the requesting client
-        only. The month runs from the 1st (00:00 in the configured timezone) to now. A
-        failed computation replies status=0 rather than no reply, so the stats grid never
-        hangs. The flat tariff (€/kWh from config, or None) turns charger energy into a
-        cost estimate here, keeping pricing out of the loader.
+        consumption/km, sessions, spot-priced cost, home import + cost) and replies to the
+        requesting client only. The month runs from the 1st (00:00 in the configured
+        timezone) to now. Both cost fields are computed inside month_summary (the loader
+        owns the spot provider + flat tariff), so this handler just derives the window and
+        packs. A failed computation replies status=0 rather than no reply, so the stats
+        grid never hangs.
         '''
         summary = None
         try:
@@ -636,20 +640,6 @@ def _register_handlers(
             now_ms = int(now.timestamp() * 1000)
             month_start_ms = int(month_start.timestamp() * 1000)
             summary = await charging_loader.month_summary(month_start_ms, now_ms)
-            tariff = config.electricity_price_eur_per_kwh
-            charger_kwh = summary.get("charger_kwh", float("nan"))
-            summary["charging_cost_eur"] = (
-                charger_kwh * tariff
-                if (tariff is not None and not math.isnan(charger_kwh))
-                else float("nan")
-            )
-            # Total home electricity cost this month (all grid import * flat tariff).
-            home_grid_kwh = summary.get("home_grid_kwh", float("nan"))
-            summary["home_cost_eur"] = (
-                home_grid_kwh * tariff
-                if (tariff is not None and not math.isnan(home_grid_kwh))
-                else float("nan")
-            )
         except Exception as e:
             logger.warning("CHARGING_GET_MONTH failed: %s: %s", type(e).__name__, e)
         await server.send_to(writer, _build_charging_month_frame(summary))
@@ -756,11 +746,24 @@ async def main():
     trip_loader = TripLoader(influx_handler, config)
     logger.debug("Trip loader initialized")
 
+    # Spot pricing (issue #12): shared fetch/cache/convert core for Nord Pool FI prices.
+    # Constructed unconditionally (independent of the charger) — the live price tile and
+    # the on-demand cost path both use it; when disabled in config every method no-ops and
+    # cost falls back to the flat tariff.
+    spot_provider = SpotPriceProvider(config)
+    logger.debug("Spot price provider initialized")
+
     # Charging-loss analysis (myenergi): stateless, reads DetailedChargeState +
     # myenergi_data history from InfluxDB on demand. Constructed unconditionally so the
-    # charging handlers always answer (an empty list when no charger data exists).
-    charging_loader = ChargingLoader(influx_handler, config)
+    # charging handlers always answer (an empty list when no charger data exists). The spot
+    # provider prices its sessions + month cost (flat tariff fallback).
+    charging_loader = ChargingLoader(influx_handler, config, spot_provider=spot_provider)
     logger.debug("Charging loader initialized")
+
+    # Live spot price broadcast (the Charging view's current-price tile). Always-on (works
+    # without a Zappi); run() no-ops when spot pricing is disabled.
+    spot_price_service = SpotPriceService(server=server, config=config, provider=spot_provider)
+    logger.debug("Spot price service initialized")
 
     # MyEnergi (Zappi) charger streaming + logging: optional. Absent credentials -> the
     # service is not started (a deployment without a charger still runs), while the
@@ -786,7 +789,7 @@ async def main():
 
     # Wire incoming-message dispatch and on-connect snapshot before start().
     _register_handlers(server, mm, vehicle, trip_loader, charging_loader, config)
-    services = [vehicle, mm, weather]
+    services = [vehicle, mm, weather, spot_price_service]
     if myenergi is not None:
         services.append(myenergi)
     for service in services:
@@ -802,8 +805,9 @@ async def main():
     t2 = asyncio.create_task(server.start())
     t3 = mm.get_run_task()
     t4 = weather.get_run_task()
+    t5 = spot_price_service.get_run_task()
 
-    tasks = [t1, t2, t3, t4]
+    tasks = [t1, t2, t3, t4, t5]
     if myenergi is not None:
         tasks.append(myenergi.get_run_task())
 

--- a/backend/src/utils/config_parser.py
+++ b/backend/src/utils/config_parser.py
@@ -92,6 +92,19 @@ class Config:
         "sessionMergeMinutes": 5,
     }
 
+    # Spot-price tunables (issue #12). Like the myenergi block, not a REQUIRED_KEY: a
+    # gitignored config.json may omit it and the stack must still start. A partial
+    # "spotPrice" block is merged over these per-key (see spot_price_config). No secret
+    # here — the sähkötin.fi source needs no API key. When "enabled" is false (or the
+    # block is absent) the Charging view falls back to the flat electricityPriceEurPerKwh
+    # tariff. All-in €/kWh for an hour = (spot + marginCentsPerKwh/100) * (1 + vatPercent/100).
+    _SPOT_PRICE_DEFAULTS = {
+        "enabled": True,
+        "vatPercent": 25.5,
+        "marginCentsPerKwh": 0.0,
+        "baseUrl": "https://sahkotin.fi/prices",
+    }
+
     def __init__(self, config_path: str):
         if not config_path:
             raise RuntimeError("Config path is empty or None")
@@ -217,3 +230,17 @@ class Config:
           the surrounding session rather than splitting it (the charging analogue of
           the trip block's min_stop_minutes).'''
         return {**self._MYENERGI_DEFAULTS, **self.__data.get("myenergi", {})}
+
+    @property
+    def spot_price_config(self) -> dict:
+        '''Nord Pool spot-price tunables (issue #12), with defaults filled in for any
+        missing key so a fully or partially absent "spotPrice" block is safe:
+        - enabled: master switch. False -> the Charging view keeps using the flat
+          electricityPriceEurPerKwh tariff and no live-price service runs.
+        - vatPercent: Finnish electricity VAT applied on top of the wholesale price
+          (25.5% since 2024-09-01).
+        - marginCentsPerKwh: the seller's fixed margin (c/kWh) added to the raw spot
+          price before VAT, approximating a real spot contract's energy price.
+        - baseUrl: the sähkötin.fi range endpoint; config-driven so an alternate
+          no-key source (e.g. sahkonhintatanaan.fi) can be swapped in without code.'''
+        return {**self._SPOT_PRICE_DEFAULTS, **self.__data.get("spotPrice", {})}

--- a/backend/src/utils/protocol.py
+++ b/backend/src/utils/protocol.py
@@ -139,9 +139,11 @@ CHARGING_LIST = 0x81       # B->F: req_start_ms(8B) + req_end_ms(8B) + count(2B)
                            #       (the echoed request window lets the client drop an out-of-order reply)
 CHARGING_GET_SUMMARY = 0x82  # F->B: start_ms(8B) + end_ms(8B)  — the selected session's window
 CHARGING_SUMMARY = 0x83      # B->F: session_id(8B) + status(1B) + start_ms(8B) + end_ms(8B)
-                             #       + 9*double(8B): charger_kwh, ac_in_kwh, battery_kwh,
+                             #       + 11*double(8B): charger_kwh, ac_in_kwh, battery_kwh,
                              #       loss_cable_kwh, loss_conversion_kwh, loss_total_kwh,
-                             #       loss_total_pct, start_soc, end_soc (any may be NaN)
+                             #       loss_total_pct, start_soc, end_soc, cost_eur,
+                             #       avg_price_eur_per_kwh (any may be NaN — cost is NaN when
+                             #       spot pricing is off/unavailable and no flat tariff is set)
 
 # Month-to-date charging aggregate (the Charging view's stats grid). Request/response,
 # replied to the requesting client only. The backend derives the month window from the
@@ -159,6 +161,16 @@ CHARGING_MONTH = 0x85      # B->F: status(1B) + 13*double(8B): charger_kwh, car_
 # logged every poll so the series is gap-free.
 CHARGER_GET_HISTORY = 0x86  # F->B: range_code(1B) + id(len(2B)+UTF-8) + start_ms(8B) + end_ms(8B)
 CHARGER_HISTORY = 0x87      # B->F: id(len(2B)+UTF-8) + status(1B) + count(4B) + count*(ts_ms(8B)+value(8B double))
+
+# Live Nord Pool spot electricity price (the Charging view's current-price tile). A
+# broadcast, like CHARGER_STREAM: SpotPriceService fetches the hourly FI-zone spot price
+# (sähkötin.fi), applies VAT + seller margin, and re-broadcasts the current hour's price
+# once per hour. status is 0 when no price is available yet (fetch failed / unpublished),
+# else 1. spot is the raw wholesale price (€/kWh, no VAT); all_in is the estimate the tiles
+# price energy with = (spot + margin) * (1 + VAT). hour_start_ms is the UTC start of the
+# price's hour, so the frontend can tell whether the tile is current.
+SPOT_PRICE_STREAM = 0x88    # B->F: status(1B) + hour_start_ms(8B) + spot_eur_per_kwh(8B double)
+                            #       + all_in_eur_per_kwh(8B double) (both NaN when status 0)
 
 # Maximum accepted size of a single incoming message (defensive cap)
 MAX_MSG_SIZE = 1024 * 1024  # 1 MB

--- a/backend/tests/test_spot_price.py
+++ b/backend/tests/test_spot_price.py
@@ -1,0 +1,235 @@
+'''
+Unit tests for the spot-price cost math (issue #12): the pure, I/O-free helpers that turn
+raw Nord Pool prices + logged energy into per-hour cost. These are the error-prone bits —
+unit conversion, hourly bucketing, and hour-boundary integration — so they are pinned here.
+
+Runnable two ways:
+  - under pytest (test_* functions), once pytest is added as a dev dependency, or
+  - standalone now: `uv run python tests/test_spot_price.py` (a __main__ runner executes each
+    test and reports pass/fail), so the logic is validated without new dependencies.
+'''
+import math
+import os
+import sys
+
+# Make the backend package importable whether run standalone or under pytest.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from types import SimpleNamespace  # noqa: E402
+
+from src.charging_service.spot_price import (  # noqa: E402
+    SpotPriceProvider,
+    _hour_floor_ms,
+    _parse_iso_z,
+    price_hourly_energy,
+)
+from src.charging_service.charging_session import (  # noqa: E402
+    bucket_positive_increments_by_hour,
+)
+from src.influxdb_service.influxdb_handler import (  # noqa: E402
+    integrate_power_series_hourly,
+)
+
+HOUR = 3_600_000
+# A clean UTC hour boundary to anchor the fixtures on (2023-11-14T22:00:00Z).
+H0 = _hour_floor_ms(1_700_000_000_000)
+H1 = H0 + HOUR
+H2 = H0 + 2 * HOUR
+
+
+def _provider(vat=25.5, margin_c=0.0, enabled=True):
+    '''Builds a SpotPriceProvider over a stub config (no network is touched by the tests).'''
+    config = SimpleNamespace(spot_price_config={
+        "enabled": enabled,
+        "vatPercent": vat,
+        "marginCentsPerKwh": margin_c,
+        "baseUrl": "https://example.invalid/prices",
+    })
+    return SpotPriceProvider(config)
+
+
+def _ingest(provider, entries):
+    '''Feeds a sähkötin-shaped response into the provider's cache (bypasses the network).'''
+    # __ingest is name-mangled; reach it directly so the test needs no HTTP.
+    provider._SpotPriceProvider__ingest({"prices": entries})
+
+
+# ── _hour_floor_ms / _parse_iso_z ──────────────────────────────────────────────
+
+def test_hour_floor_ms():
+    assert _hour_floor_ms(H0) == H0
+    assert _hour_floor_ms(H0 + 1) == H0
+    assert _hour_floor_ms(H1 - 1) == H0
+    assert _hour_floor_ms(H1) == H1
+
+
+def test_parse_iso_z():
+    assert _parse_iso_z("2026-07-07T00:00:00.000Z") == 1783382400000
+    # No fractional part must also parse.
+    assert _parse_iso_z("2026-07-07T01:00:00Z") == 1783386000000
+
+
+# ── price_hourly_energy ────────────────────────────────────────────────────────
+
+def test_price_pure_spot():
+    # 2 kWh @ 0.10 + 3 kWh @ 0.20 = 0.80 €.
+    cost = price_hourly_energy({H0: 2.0, H1: 3.0}, {H0: 0.10, H1: 0.20})
+    assert math.isclose(cost, 0.80)
+
+
+def test_price_flat_fallback_for_missing_hour():
+    # H1 has no spot price -> flat 0.15 fallback. 2*0.10 + 3*0.15 = 0.65.
+    cost = price_hourly_energy({H0: 2.0, H1: 3.0}, {H0: 0.10}, flat_fallback=0.15)
+    assert math.isclose(cost, 0.65)
+
+
+def test_price_no_spot_all_flat_equals_flat_times_total():
+    # No spot at all + flat tariff == flat * total energy (the fallback path).
+    cost = price_hourly_energy({H0: 2.0, H1: 3.0}, {}, flat_fallback=0.1)
+    assert math.isclose(cost, 0.5)
+
+
+def test_price_nan_when_nothing_priceable():
+    assert math.isnan(price_hourly_energy({H0: 2.0}, {}, flat_fallback=None))
+
+
+def test_price_skips_nan_energy():
+    cost = price_hourly_energy({H0: float("nan"), H1: 3.0}, {H0: 0.10, H1: 0.20})
+    assert math.isclose(cost, 0.60)
+
+
+def test_price_drops_unpriceable_hour_but_keeps_rest():
+    # H1 has neither spot nor flat -> its energy is dropped, H0 still counts.
+    cost = price_hourly_energy({H0: 2.0, H1: 3.0}, {H0: 0.10}, flat_fallback=None)
+    assert math.isclose(cost, 0.20)
+
+
+# ── bucket_positive_increments_by_hour ─────────────────────────────────────────
+
+def test_bucket_basic_two_increments_same_hour():
+    ts = [H0, H0 + 10_000, H0 + 20_000]
+    vals = [1.0, 1.5, 2.0]  # +0.5, +0.5 -> both attributed to H0
+    assert bucket_positive_increments_by_hour(ts, vals) == {H0: 1.0}
+
+
+def test_bucket_ignores_carry_in():
+    # A large first value (carried in from a prior charge) is the baseline, not counted;
+    # only in-window increments are summed.
+    ts = [H0, H0 + 10_000]
+    vals = [12.0, 12.4]  # +0.4
+    assert math.isclose(bucket_positive_increments_by_hour(ts, vals)[H0], 0.4)
+
+
+def test_bucket_clamps_reset():
+    # Accumulator reset (drop) contributes 0, not a negative.
+    ts = [H0, H0 + 10_000, H0 + 20_000]
+    vals = [5.0, 0.0, 0.3]  # -5.0 (clamped to 0), +0.3
+    assert math.isclose(bucket_positive_increments_by_hour(ts, vals)[H0], 0.3)
+
+
+def test_bucket_splits_across_hours_by_later_sample():
+    # Increment recorded just after the hour boundary lands in the later hour.
+    ts = [H1 - 5_000, H1 + 5_000]
+    vals = [2.0, 2.6]  # +0.6, later sample is in H1
+    result = bucket_positive_increments_by_hour(ts, vals)
+    assert set(result.keys()) == {H1}
+    assert math.isclose(result[H1], 0.6)
+
+
+def test_bucket_too_short():
+    assert bucket_positive_increments_by_hour([H0], [1.0]) == {}
+    assert bucket_positive_increments_by_hour([], []) == {}
+
+
+# ── integrate_power_series_hourly ──────────────────────────────────────────────
+
+def test_integrate_constant_power_one_hour():
+    # 1000 W held across exactly one hour = 1.0 kWh in that hour.
+    result = integrate_power_series_hourly([H0, H1], [1000.0, 1000.0])
+    assert set(result.keys()) == {H0}
+    assert math.isclose(result[H0], 1.0)
+
+
+def test_integrate_splits_at_hour_boundary():
+    # 1000 W constant, sampled 40 min before to 20 min after the H1 boundary:
+    # 0.6667 kWh into H0, 0.3333 kWh into H1.
+    result = integrate_power_series_hourly([H1 - 40 * 60_000, H1 + 20 * 60_000],
+                                           [1000.0, 1000.0])
+    assert math.isclose(result[H0], 1000.0 * (40 / 60) / 1000.0)
+    assert math.isclose(result[H1], 1000.0 * (20 / 60) / 1000.0)
+
+
+def test_integrate_clamps_export_to_zero():
+    # Negative power (grid export) is clamped to 0 -> no imported energy.
+    result = integrate_power_series_hourly([H0, H1], [-2000.0, -2000.0])
+    assert result.get(H0, 0.0) == 0.0
+
+
+def test_integrate_trapezoid_ramp():
+    # Power ramps 0 -> 3600 W over one hour: mean 1800 W -> 1.8 kWh.
+    result = integrate_power_series_hourly([H0, H1], [0.0, 3600.0])
+    assert math.isclose(result[H0], 1.8)
+
+
+def test_integrate_too_short():
+    assert integrate_power_series_hourly([H0], [1000.0]) == {}
+
+
+# ── SpotPriceProvider conversion (no network) ──────────────────────────────────
+
+def test_provider_mwh_to_kwh_and_all_in():
+    p = _provider(vat=25.5, margin_c=0.5)  # margin 0.5 c/kWh = 0.005 €/kWh
+    _ingest(p, [{"date": "2023-11-14T22:00:00.000Z", "value": 100.0}])  # 100 €/MWh
+    raw = p.raw_price_at(H0)
+    assert raw is not None
+    assert math.isclose(raw, 0.10)  # 100 €/MWh -> 0.10 €/kWh
+    # all_in = (0.10 + 0.005) * 1.255
+    assert math.isclose(p._all_in(raw), (0.10 + 0.005) * 1.255)
+
+
+def test_provider_averages_subhour_entries():
+    p = _provider()
+    _ingest(p, [
+        {"date": "2023-11-14T22:00:00.000Z", "value": 100.0},
+        {"date": "2023-11-14T22:15:00.000Z", "value": 200.0},
+        {"date": "2023-11-14T22:30:00.000Z", "value": 300.0},
+        {"date": "2023-11-14T22:45:00.000Z", "value": 400.0},
+    ])
+    # mean(100,200,300,400)=250 €/MWh -> 0.25 €/kWh
+    raw = p.raw_price_at(H0)
+    assert raw is not None
+    assert math.isclose(raw, 0.25)
+
+
+def test_provider_skips_nan_and_bad_entries():
+    p = _provider()
+    _ingest(p, [
+        {"date": "2023-11-14T22:00:00.000Z", "value": float("nan")},
+        {"date": "bogus", "value": 100.0},
+        {"value": 100.0},  # missing date
+        {"date": "2023-11-14T23:00:00.000Z", "value": 50.0},
+    ])
+    assert p.raw_price_at(H0) is None       # NaN entry dropped
+    raw = p.raw_price_at(H1)
+    assert raw is not None
+    assert math.isclose(raw, 0.05)
+
+
+def test_provider_disabled_raw_none():
+    p = _provider(enabled=False)
+    assert p.enabled is False
+
+
+if __name__ == "__main__":
+    tests = [(name, obj) for name, obj in sorted(globals().items())
+             if name.startswith("test_") and callable(obj)]
+    failures = 0
+    for name, fn in tests:
+        try:
+            fn()
+            print(f"PASS {name}")
+        except Exception as exc:  # noqa: BLE001 — standalone runner surfaces any failure
+            failures += 1
+            print(f"FAIL {name}: {type(exc).__name__}: {exc}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    sys.exit(1 if failures else 0)

--- a/config_template.json
+++ b/config_template.json
@@ -392,5 +392,11 @@
         "pollIntervalActiveSeconds": 10,
         "minSessionEnergyKwh": 0.5,
         "sessionMergeMinutes": 5
+    },
+    "spotPrice": {
+        "enabled": true,
+        "vatPercent": 25.5,
+        "marginCentsPerKwh": 0.0,
+        "baseUrl": "https://sahkotin.fi/prices"
     }
 }

--- a/frontend_v2/core/charging/chargingdata.cpp
+++ b/frontend_v2/core/charging/chargingdata.cpp
@@ -30,6 +30,9 @@ void ChargingData::onPacket(quint8 type, const QByteArray &payload) {
         case protocol::CHARGER_STREAM:
             parseStream(payload);
             break;
+        case protocol::SPOT_PRICE_STREAM:
+            parseSpotPrice(payload);
+            break;
         case protocol::CHARGING_MONTH:
             parseMonth(payload);
             break;
@@ -130,6 +133,31 @@ void ChargingData::parseStream(const QByteArray &payload) {
         emit chargeChanged();
         emit chargeTick();
     }
+}
+
+void ChargingData::parseSpotPrice(const QByteArray &payload) {
+    QDataStream stream(payload);
+    stream.setByteOrder(QDataStream::BigEndian);
+    QIODevice *device = stream.device();
+
+    // status(1) + hour_start_ms(8) + spot(8) + all_in(8) = 25 bytes.
+    if (device->bytesAvailable() < 25) {
+        logger.warning(QStringLiteral("Spot-price frame too short"));
+        return;
+    }
+    quint8 status;
+    qint64 hourStartMs;
+    double spot;
+    double allIn;
+    stream >> status >> hourStartMs >> spot >> allIn;
+
+    // status 0 => no price this hour (fetch failed / unpublished): drop to "no price" so
+    // the tile shows "—" rather than a stale value.
+    m_hasSpotPrice = (status == 1);
+    m_spotHourStartMs = static_cast<double>(hourStartMs);
+    m_spotRawEurPerKwh = spot;
+    m_spotPriceEurPerKwh = allIn;
+    emit spotPriceChanged();
 }
 
 void ChargingData::parseMonth(const QByteArray &payload) {

--- a/frontend_v2/core/charging/chargingdata.hh
+++ b/frontend_v2/core/charging/chargingdata.hh
@@ -43,6 +43,15 @@ class ChargingData : public QObject {
     Q_PROPERTY(int l1Phase READ l1Phase NOTIFY liveStateChanged)
     Q_PROPERTY(QVariantMap raw READ raw NOTIFY liveStateChanged)
 
+    // Live Nord Pool spot price (SPOT_PRICE_STREAM). `hasSpotPrice` stays false until the
+    // first status=1 frame (or when spot pricing is disabled backend-side). price is the
+    // VAT+margin all-in €/kWh the tiles use; rawPrice is the wholesale €/kWh; hourStartMs
+    // is the UTC start of the priced hour.
+    Q_PROPERTY(bool hasSpotPrice READ hasSpotPrice NOTIFY spotPriceChanged)
+    Q_PROPERTY(double spotPriceEurPerKwh READ spotPriceEurPerKwh NOTIFY spotPriceChanged)
+    Q_PROPERTY(double spotRawEurPerKwh READ spotRawEurPerKwh NOTIFY spotPriceChanged)
+    Q_PROPERTY(double spotHourStartMs READ spotHourStartMs NOTIFY spotPriceChanged)
+
     // Month-to-date aggregate (CHARGING_MONTH): `valid` + the 12 fields (NaN -> "—").
     Q_PROPERTY(QVariantMap monthSummary READ monthSummary NOTIFY monthChanged)
     Q_PROPERTY(bool monthLoading READ monthLoading NOTIFY monthLoadingChanged)
@@ -67,6 +76,10 @@ public:
     double supplyFrequency() const { return m_supplyFrequency; }
     int l1Phase() const { return m_l1Phase; }
     QVariantMap raw() const { return m_raw; }
+    bool hasSpotPrice() const { return m_hasSpotPrice; }
+    double spotPriceEurPerKwh() const { return m_spotPriceEurPerKwh; }
+    double spotRawEurPerKwh() const { return m_spotRawEurPerKwh; }
+    double spotHourStartMs() const { return m_spotHourStartMs; }
     QVariantMap monthSummary() const { return m_month; }
     bool monthLoading() const { return m_monthLoading; }
     QVariantMap gridSeries() const { return seriesMap(m_grid); }
@@ -84,6 +97,7 @@ public:
 
 signals:
     void liveStateChanged();
+    void spotPriceChanged();
     void monthChanged();
     void monthReady();
     void monthLoadingChanged();
@@ -113,6 +127,7 @@ private:
     };
 
     void parseStream(const QByteArray &payload);
+    void parseSpotPrice(const QByteArray &payload);
     void parseMonth(const QByteArray &payload);
     void parseChargerHistory(const QByteArray &payload);
     void sendHistoryRequest(const QString &id);
@@ -138,6 +153,12 @@ private:
     double m_supplyFrequency = 0.0;
     int m_l1Phase = 0;
     QVariantMap m_raw;
+
+    // Live spot price (SPOT_PRICE_STREAM).
+    bool m_hasSpotPrice = false;
+    double m_spotPriceEurPerKwh = 0.0;
+    double m_spotRawEurPerKwh = 0.0;
+    double m_spotHourStartMs = 0.0;
 
     // Month aggregate + reconnect-retry flag.
     QVariantMap m_month;

--- a/frontend_v2/core/protocol.hh
+++ b/frontend_v2/core/protocol.hh
@@ -120,11 +120,16 @@ inline constexpr quint8 CHARGER_MODE_STOPPED = 4;
 inline constexpr quint8 CHARGING_GET_LIST = 0x80;    // F->B: start_ms(8B) + end_ms(8B)
 inline constexpr quint8 CHARGING_LIST = 0x81;        // B->F: req_start(8B)+req_end(8B)+count(2B)+count*(start(8B)+end(8B)+charger_kwh(8B))
 inline constexpr quint8 CHARGING_GET_SUMMARY = 0x82; // F->B: start_ms(8B) + end_ms(8B)
-inline constexpr quint8 CHARGING_SUMMARY = 0x83;     // B->F: session_id(8B)+status(1B)+start(8B)+end(8B)+9*double
+inline constexpr quint8 CHARGING_SUMMARY = 0x83;     // B->F: session_id(8B)+status(1B)+start(8B)+end(8B)+11*double (…, end_soc, cost_eur, avg_price_eur_per_kwh)
 inline constexpr quint8 CHARGING_GET_MONTH = 0x84;   // F->B: (empty)
 inline constexpr quint8 CHARGING_MONTH = 0x85;       // B->F: status(1B) + 13*double (charger_kwh, car_kwh, wasted_kwh, efficiency_pct, car_wh_per_km, charger_wh_per_km, driving_kwh, km_month, session_count, total_charge_s, charging_cost_eur, home_grid_kwh, home_cost_eur)
 inline constexpr quint8 CHARGER_GET_HISTORY = 0x86;  // F->B: range_code(1B)+id(len(2B)+UTF-8)+start(8B)+end(8B)
 inline constexpr quint8 CHARGER_HISTORY = 0x87;      // B->F: id(len(2B)+UTF-8)+status(1B)+count(4B)+count*(ts(8B)+value(8B double))
+
+// Live Nord Pool spot price broadcast (the Charging view's current-price tile). Mirror of
+// protocol.py: status 0 => no price (fields NaN), else 1. spot is raw wholesale €/kWh,
+// allIn the VAT+margin estimate; hourStartMs is the UTC start of the priced hour.
+inline constexpr quint8 SPOT_PRICE_STREAM = 0x88;    // B->F: status(1B)+hour_start_ms(8B)+spot(8B double)+all_in(8B double)
 
 // History request range codes (mirror the backend _RANGE_* and the QML RangeSelector)
 inline constexpr quint8 HISTORY_RANGE_1H = 0;

--- a/frontend_v2/items/charging/ChargingLiveCard.qml
+++ b/frontend_v2/items/charging/ChargingLiveCard.qml
@@ -20,6 +20,8 @@ Item {
     }
     function power(w) { return has(w) ? Math.round(w) + " W" : "—" }
     function energy(kwh) { return has(kwh) ? kwh.toFixed(2) + " kWh" : "—" }
+    // All-in €/kWh -> c/kWh; "—" until a live spot price arrives (or when disabled).
+    function price(eur) { return (Charging.hasSpotPrice && has(eur)) ? (eur * 100).toFixed(2) + " c/kWh" : "—" }
 
     // One title-over-value stat in the row.
     component LiveStat: Column {
@@ -61,5 +63,6 @@ Item {
         LiveStat { t: qsTr("Istunto");    v: root.energy(Charging.sessionEnergyKwh) }
         LiveStat { t: qsTr("Latausteho"); v: root.power(Charging.chargePowerW) }
         LiveStat { t: qsTr("Verkkoteho"); v: root.power(Charging.gridPowerW) }
+        LiveStat { t: qsTr("Hinta");      v: root.price(Charging.spotPriceEurPerKwh) }
     }
 }


### PR DESCRIPTION
## Summary

Adds **hourly Nord Pool FI spot pricing** to the Charging (Lataus) view, replacing the flat tariff as the primary cost basis for the month cost tiles, adding per-session cost, and adding a live current-price tile. The flat `electricityPriceEurPerKwh` becomes a per-hour fallback.

Prices are fetched **on demand** from the free no-key **sähkötin.fi** range API — no self-logging — so past charging sessions are priced **retroactively** at the actual spot price for the hour each kWh was drawn.

Backend:
- **`charging_service/spot_price.py`** (`SpotPriceProvider`) — fetch/cache/convert. Raw €/MWh → all-in `(spot + margin) × (1 + VAT)` €/kWh, keyed by **UTC hour** (DST-safe), normalized to hourly buckets (robust to the 15-min market resolution), immutable past hours cached for the process lifetime. Includes the pure `price_hourly_energy` helper (energy×price with per-hour flat fallback).
- **`charging_service/spot_price_service.py`** (`SpotPriceService`) — thin always-on `WeatherService`-style broadcaster: pre-warms today+tomorrow, re-broadcasts the current hour's price as **`SPOT_PRICE_STREAM` (0x88)** hourly, snapshots on connect. Works with no Zappi; `run()` no-ops when disabled.
- **Cost moved into the loader/session** (the loader owns the provider + flat tariff): `ChargingSession.summary()` buckets its `ChargeAdded` positive increments by UTC hour and prices each → `cost_eur` + `avg_price_eur_per_kwh` (0x83: 9 → 11 doubles). `month_summary` sums per-session costs (`charging_cost_eur`) and prices the hourly home import (`home_cost_eur`). The month handler no longer computes cost.
- **`InfluxDBHandler.read_grid_import_kwh_hourly`** + pure `integrate_power_series_hourly` (trapezoidal per-UTC-hour integral, export clamped to 0, hour-boundary split) → `{utc_hour_ms: kwh}`; replaces the month-only `read_grid_import_kwh_month`.
- New **`spotPrice`** config block (`enabled` / `vatPercent` / `marginCentsPerKwh` / `baseUrl`). Master switch: `enabled: false` keeps flat-tariff billing (no live service).

Frontend (`frontend_v2`):
- `ChargingData` parses `0x88` → live price properties; `ChargingLiveCard` shows a **"Hinta"** tile in c/kWh. Month cost tiles unchanged (values now spot-based). Per-session cost fields (0x83) are parsed backend-side and wire-ready for a future session-detail UI.

Tests/docs:
- `backend/tests/test_spot_price.py` — 22 tests pinning the pure cost math (conversion, hourly normalization, increment/GridPower bucketing). Runs under pytest or standalone; **22/22 pass**.
- `CLAUDE.md` updated (§2, §4, §5.1, §5.2.5, §5.2.7, §7.7).

## Reason

Part of issue #12. Finland is on Nord Pool hourly spot pricing, so a single flat number is a poor estimate — overnight vs. evening-peak charging can differ several-fold. This prices energy against what it actually cost that hour, while keeping the flat tariff as a graceful fallback. This is a first, self-contained slice; more (e.g. per-session cost UI, ENTSO-E fallback for older sessions) can follow.

## Manual verification

Backend (agent-validated):
- `python -m compileall backend/src` passes; `uv run python backend/tests/test_spot_price.py` → 22/22.
- With `spotPrice.enabled: true`, start the stack: confirm a `SpotPriceService` initial fetch in the logs + a `SPOT_PRICE_STREAM` snapshot on connect; cross-check one hour against the raw sähkötin URL (× (1+VAT) + margin).
- Request `CHARGING_GET_MONTH`: Latauskulut / Sähkölasku now differ from `total_kwh × flat_tariff` and match a manual hourly sum for a sample day.
- Fallback: `spotPrice.enabled: false` → costs use the flat tariff; unset both → "—". API down → cached/partial prices, no crash.

Frontend (maintainer builds — agent does not build the frontend):
- Build `frontend_v2`, open **Lataus**: the live **Hinta** tile updates and the month cost tiles populate.

## Screenshots

_To be added by the maintainer (Lataus view: live Hinta tile + month cost tiles)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)