### PR TITLE
Fix: silence two frontend startup warnings (stream-46 route + Controls style)

### DIFF
--- a/frontend_v2/core/tesla/tesla_properties.json
+++ b/frontend_v2/core/tesla/tesla_properties.json
@@ -46,6 +46,7 @@
         { "name": "RearDefrostEnabled", "streamId": 42, "type": "bool", "unit": "" },
         { "name": "SeatHeaterLeft", "streamId": 43, "type": "double", "unit": "" },
         { "name": "SeatHeaterRight", "streamId": 44, "type": "double", "unit": "" },
-        { "name": "EstBatteryRange", "streamId": 45, "type": "double", "unit": "km" }
+        { "name": "EstBatteryRange", "streamId": 45, "type": "double", "unit": "km" },
+        { "name": "ACChargingEnergyIn", "streamId": 46, "type": "double", "unit": "kWh" }
     ]
 }

--- a/frontend_v2/core/tesla/tesladata_gen.cpp
+++ b/frontend_v2/core/tesla/tesladata_gen.cpp
@@ -54,6 +54,7 @@ int TeslaDataGen::valueTypeForStream(quint16 streamId) {
         case 43: return 0;
         case 44: return 0;
         case 45: return 0;
+        case 46: return 0;
         default: return -1;
     }
 }
@@ -80,6 +81,7 @@ QString TeslaDataGen::unitOf(const QString &propertyName) const {
         { QStringLiteral("drivenToday"), QStringLiteral("km") },
         { QStringLiteral("drivenThisMonth"), QStringLiteral("km") },
         { QStringLiteral("estBatteryRange"), QStringLiteral("km") },
+        { QStringLiteral("aCChargingEnergyIn"), QStringLiteral("kWh") },
     };
     return units.value(propertyName);
 }
@@ -132,6 +134,7 @@ bool TeslaDataGen::applyValue(quint16 streamId, const QVariant &value) {
         case 43: m_seatHeaterLeft = value.toDouble(); emit seatHeaterLeftChanged(); return true;
         case 44: m_seatHeaterRight = value.toDouble(); emit seatHeaterRightChanged(); return true;
         case 45: m_estBatteryRange = value.toDouble(); emit estBatteryRangeChanged(); return true;
+        case 46: m_aCChargingEnergyIn = value.toDouble(); emit aCChargingEnergyInChanged(); return true;
         default: return false;
     }
 }

--- a/frontend_v2/core/tesla/tesladata_gen.hh
+++ b/frontend_v2/core/tesla/tesladata_gen.hh
@@ -60,6 +60,7 @@ class TeslaDataGen : public QObject {
     Q_PROPERTY(double seatHeaterLeft READ seatHeaterLeft NOTIFY seatHeaterLeftChanged)
     Q_PROPERTY(double seatHeaterRight READ seatHeaterRight NOTIFY seatHeaterRightChanged)
     Q_PROPERTY(double estBatteryRange READ estBatteryRange NOTIFY estBatteryRangeChanged)
+    Q_PROPERTY(double aCChargingEnergyIn READ aCChargingEnergyIn NOTIFY aCChargingEnergyInChanged)
 
 public:
     explicit TeslaDataGen(QObject *parent = nullptr) : QObject(parent) {}
@@ -110,6 +111,7 @@ public:
     double seatHeaterLeft() const { return m_seatHeaterLeft; }
     double seatHeaterRight() const { return m_seatHeaterRight; }
     double estBatteryRange() const { return m_estBatteryRange; }
+    double aCChargingEnergyIn() const { return m_aCChargingEnergyIn; }
 
     // Expected protocol value_type (0=double,1=string,2=bool,3=location)
     // for a stream id, or -1 if the id is not in the registry.
@@ -165,6 +167,7 @@ signals:
     void seatHeaterLeftChanged();
     void seatHeaterRightChanged();
     void estBatteryRangeChanged();
+    void aCChargingEnergyInChanged();
 
 protected:
     // Sets the field bound to streamId from value (interpreted per the
@@ -218,6 +221,7 @@ private:
     double m_seatHeaterLeft = 0.0;
     double m_seatHeaterRight = 0.0;
     double m_estBatteryRange = 0.0;
+    double m_aCChargingEnergyIn = 0.0;
 };
 
 #endif  // FRONTEND_V2_TESLADATA_GEN_HH

--- a/frontend_v2/main.cpp
+++ b/frontend_v2/main.cpp
@@ -2,6 +2,7 @@
 #include <QFontDatabase>
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
+#include <QQuickStyle>
 #include <QtQml>  // qmlRegisterSingletonInstance + QQmlEngine
 #include <memory>
 
@@ -66,6 +67,14 @@ int main(int argc, char* argv[]) {
     // and renders config/notifications.json rules. Built before the engine so it
     // is subscribed before serverClient.start() fires the first connect.
     NotificationHandler notificationHandler(&teslaData, &serverClient);
+
+    // Pin the Qt Quick Controls style to Basic — the style the custom control
+    // styling (e.g. TripComboBox's themed field / popup / delegate) is written for.
+    // Without this the platform default wins: on Windows that's the native style,
+    // which refuses ComboBox background/contentItem customization (it warns and
+    // renders native), so the dark theme only took on the Linux target. Must be set
+    // before the engine loads any Controls.
+    QQuickStyle::setStyle(QStringLiteral("Basic"));
 
     QQmlApplicationEngine engine;
     // The engine takes ownership of the image provider; it shares the cache with


### PR DESCRIPTION
## Summary
Fixes the two warnings seen on frontend startup / runtime, both pre-existing and unrelated to the recent TripMap work.

### 1. `tesla | No route for stream id 46`
The backend logs + streams `ACChargingEnergyIn` (`config.json` stream_id 46), but the frontend's generated route table (`tesladata_gen`, built from `tesla_properties.json`) had no entry — so `TeslaData::onPacket` logged `No route for stream id 46` and dropped the packet on every broadcast.

- Registered `ACChargingEnergyIn` (stream 46, `double`, kWh) in `tesla_properties.json` and regenerated `tesladata_gen.{hh,cpp}` (47 properties). The field is now routed and exposed as a live `aCChargingEnergyIn` property on the `Tesla` singleton, ready to bind to a widget later.

### 2. `TripComboBox.qml … current style does not support customization`
No Qt Quick Controls style was pinned, so the platform default won. On Windows that's the native style, which refuses `ComboBox` `background`/`contentItem` customization — emitting the warnings and rendering native instead of the dark theme (the theme only applied on the Linux target).

- Added `QQuickStyle::setStyle("Basic")` (+ `#include <QQuickStyle>`) in `main.cpp` before the engine loads any Controls. `Basic` is the style the custom control theming was written for.

## Manual verification
Rebuilt and ran (`scripts\build-frontend.ps1 -Run`):
- No more `No route for stream id 46` on connect / while charging.
- No `TripComboBox` style warnings; the week/trip dropdowns render fully dark on Windows (field, popup, rows, hover).

Frontend-only; no protocol / backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)