### PR TITLE
Fix: myenergi refresh failures — surface HTTP status, back off, raise poll rate (#18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -663,6 +663,12 @@ checks and let the user run the live stack.
 - Commit subjects use short imperative prefixes: `Add:`, `Fix:`, `Update:`, `Remove:`, `Create:`.
 - Keep each commit focused on one purpose.
 - PRs include: change summary, reason, manual verification steps, and screenshots for UI changes.
+- **When opening a PR, check whether the branch resolves any open issue(s).** Before writing the PR
+  body, scan the open issues (`gh issue list`) against what the branch actually changes and, for every
+  issue the work fixes, add a GitHub closing keyword (`Closes #N` / `Fixes #N`, one per issue) to the
+  PR body so the issue auto-closes on merge instead of being left open after it's really fixed. If a
+  branch touches an issue only partially, reference it (`Refs #N`) without a closing keyword. Don't
+  invent a link — only tie a PR to an issue the change genuinely resolves.
 - **Prompt to commit once work is verified.** This repo tends to accumulate uncommitted,
   manually-verified changes (the frontend isn't agent-built, so verification happens on the user's
   side). When the user confirms a feature works — i.e. they say a manual test passed — proactively

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -475,7 +475,16 @@ guards; they're the only thing preventing injection if non-config input ever rea
   measurement: `GridPower` + `ChargePower` **every poll** (gap-free for the past-hour graphs and the
   month home-import integral) and `ChargeAdded` (the session accumulator) **while charging**. Mirrors
   `WeatherService` (initial poll + APScheduler job, last frame cached for `stream_everything`), with
-  two poll cadences (idle/active). Optional — skipped when the `.env` creds are unset.
+  two poll cadences (idle/active, config-driven — default **60 s idle / 20 s active** to stay under
+  the myenergi cloud's rate limit; 10 s throttled us with 429s). `__apply_interval` is the single
+  place that reschedules the job: it picks the active/idle base then stretches it by a **capped
+  exponential backoff** (`2**consecutive_failures`, ≤ 5 min) whenever a poll fails, snapping back on
+  the first success. This matters because every failed request flips pymyenergi's `do_query_asn` back
+  on, so the next poll fires two requests (director + status) — polling a failing endpoint at full
+  cadence deepens a throttle. Refresh/resolve failures are logged via the module helper
+  `_describe_exception`, which surfaces the HTTP status a `MyenergiException` otherwise hides (its
+  ctor stores it in `.code`/`.message` but stringifies to `""`, so the old `str(e)` logged a blank
+  reason — issue #18). Optional — skipped when the `.env` creds are unset.
 - **`charging_service/`** (`ChargingLoader` + `ChargingSession`) derives charging sessions **on
   demand** from stored `DetailedChargeState` history (segmentation like `trip_service`), joined to
   the logged charger energy — no live tracking. Serves `CHARGING_GET_LIST`/`_SUMMARY`/`_MONTH` +

--- a/backend/src/myenergi_service/myenergi_service.py
+++ b/backend/src/myenergi_service/myenergi_service.py
@@ -63,6 +63,36 @@ _CHARGE_ADDED_ID = "ChargeAdded"
 _CHARGE_POWER_ID = "ChargePower"
 _GRID_POWER_ID = "GridPower"
 
+# When a poll fails the myenergi cloud has almost always throttled us (429) or hiccuped
+# (5xx), and every failure also flips pymyenergi's do_query_asn back on, so the *next*
+# poll fires two requests (director ASN + status) instead of one — polling a failing
+# endpoint at the normal cadence therefore deepens a throttle. On consecutive failures the
+# interval is stretched by 2**failures (capped), snapping back to the normal idle/active
+# cadence on the first poll that succeeds.
+_BACKOFF_FACTOR_CAP = 4         # cap the multiplier at 2**4 = 16x the base interval
+_BACKOFF_MAX_INTERVAL_S = 300   # ...and never back off slower than once every 5 minutes
+
+
+def _describe_exception(e: Exception) -> str:
+    '''
+    Renders an exception for a log line, surfacing the HTTP status pymyenergi otherwise
+    hides. A pymyenergi MyenergiException stringifies to '' — its constructor stores the
+    status in .code / .message but never forwards code to the base Exception — so str(e)
+    alone logs a blank reason (the "MyenergiException:" with nothing after it). This pulls
+    .code and .message off the exception instead (e.g. "MyenergiException 429
+    TOO_MANY_REQUESTS"), falling back to str(e) for ordinary exceptions.
+    Arguments:
+        e (Exception): The caught exception to describe.
+    '''
+    parts = [type(e).__name__]
+    code = getattr(e, "code", None)
+    if code is not None:
+        parts.append(str(code))
+    message = getattr(e, "message", "") or str(e)
+    if message:
+        parts.append(message)
+    return " ".join(parts)
+
 
 class MyEnergiService:
     def __init__(
@@ -99,6 +129,11 @@ class MyEnergiService:
         self.__zappi: Zappi | None = None
         self.__job = None
         self.__current_interval: int | None = None
+        # Cadence inputs for __apply_interval: whether the last successful poll saw the
+        # charger charging (active vs idle base), and how many polls have failed in a row
+        # (drives the backoff). Reset to 0 on the first poll that succeeds.
+        self.__is_charging = False
+        self.__consecutive_failures = 0
 
         # Most recent framed CHARGER_STREAM packet, replayed verbatim to a newly
         # connecting client (same idea as WeatherService.__last_forecast).
@@ -166,7 +201,7 @@ class MyEnergiService:
             return True
         except Exception as e:
             # Network / auth / discovery failure: stay dormant and retry next tick.
-            logger.warning("Failed to resolve Zappi: %s: %s", type(e).__name__, e)
+            logger.warning("Failed to resolve Zappi: %s", _describe_exception(e))
             return False
 
     async def __poll(self) -> None:
@@ -181,8 +216,19 @@ class MyEnergiService:
         try:
             await self.__zappi.refresh()
         except Exception as e:
-            logger.warning("Zappi refresh failed: %s: %s", type(e).__name__, e)
+            self.__consecutive_failures += 1
+            logger.warning(
+                "Zappi refresh failed (%d in a row): %s",
+                self.__consecutive_failures, _describe_exception(e),
+            )
+            self.__apply_interval()
             return
+
+        if self.__consecutive_failures:
+            logger.info(
+                "Zappi refresh recovered after %d failure(s)", self.__consecutive_failures
+            )
+            self.__consecutive_failures = 0
 
         status = self.__zappi.status
         plug = self.__zappi.plug_status
@@ -203,7 +249,8 @@ class MyEnergiService:
         await self.__server.broadcast(self.__last_frame)
 
         await self.__log_poll(status, charge_added, power, grid_power)
-        self.__adjust_interval(status)
+        self.__is_charging = _STATUS_MAP.get(status) == protocol.CHARGER_STATUS_CHARGING
+        self.__apply_interval()
 
     def __derive_power(self, charge_added) -> float:
         '''
@@ -276,16 +323,23 @@ class MyEnergiService:
             .time(when, WritePrecision.MS)
         )
 
-    def __adjust_interval(self, status) -> None:
+    def __apply_interval(self) -> None:
         '''
-        Switches the poll cadence between the active and idle intervals based on whether
-        the charger is charging, by rescheduling the job. No-op when the desired interval
-        already matches the current one.
-        Arguments:
-            status: The Zappi status string this poll.
+        Sets the poll cadence to the desired interval by rescheduling the job, a no-op
+        when it already matches. The base cadence is the active interval while charging or
+        the idle interval otherwise; consecutive failures then stretch it by a capped
+        exponential backoff (2**failures, bounded by _BACKOFF_MAX_INTERVAL_S) so a
+        sustained cloud throttle (429) or outage is not hammered — and because each failure
+        also forces pymyenergi to re-query the director next poll, backing off is what
+        actually lets a throttle clear. The first successful poll resets the failure count,
+        snapping the cadence straight back to idle/active.
         '''
-        is_charging = _STATUS_MAP.get(status) == protocol.CHARGER_STATUS_CHARGING
-        desired = self.__active_interval if is_charging else self.__idle_interval
+        base = self.__active_interval if self.__is_charging else self.__idle_interval
+        if self.__consecutive_failures:
+            factor = 2 ** min(self.__consecutive_failures, _BACKOFF_FACTOR_CAP)
+            desired = min(base * factor, _BACKOFF_MAX_INTERVAL_S)
+        else:
+            desired = base
         if desired != self.__current_interval and self.__job is not None:
             self.__job.reschedule(trigger=IntervalTrigger(seconds=desired))
             self.__current_interval = desired

--- a/config_template.json
+++ b/config_template.json
@@ -388,8 +388,8 @@
     "electricityPriceEurPerKwh": null,
     "myenergi": {
         "zappiSerial": "",
-        "pollIntervalIdleSeconds": 30,
-        "pollIntervalActiveSeconds": 10,
+        "pollIntervalIdleSeconds": 60,
+        "pollIntervalActiveSeconds": 20,
         "minSessionEnergyKwh": 0.5,
         "sessionMergeMinutes": 5
     },


### PR DESCRIPTION
## Summary

Fixes the recurring `WARNING | ... Zappi refresh failed: MyenergiException:` (blank detail) from the myenergi poller and the underlying 429 throttling that produced it.

- **Surface the real status.** `pymyenergi`'s `MyenergiException` stores the HTTP status in `.code`/`.message` but never forwards it to the base `Exception`, so `str(e)` is empty. New module helper `_describe_exception()` reads `.code`/`.message` (e.g. `MyenergiException 429 TOO_MANY_REQUESTS`) and is used in both the refresh and Zappi-resolve paths.
- **Back off on failure.** `__adjust_interval` → `__apply_interval`: same idle/active choice, now stretched by a capped exponential backoff (`2**consecutive_failures`, ≤ 5 min) whenever a poll fails, snapping back to the normal cadence on the first success.
- **Raise the poll rate.** Default cadence → **60 s idle / 20 s active** (`config_template.json`).
- Doc: `CLAUDE.md` §5.2.7 updated; §7.5 gains a PR convention (link/close resolved issues on PR open).

## Reason

The config polled **every 10 s in both modes** (360 req/hr), which the myenergi cloud throttles with 429s. Worse, each failure flips `pymyenergi`'s `do_query_asn` back on, so the *next* poll fires **two** requests (director + status) — a feedback loop that deepens the throttle. And because the exception stringified to empty, the log never showed *why*.

Polling-rate basis: Home Assistant's myenergi integration (same `pymyenergi` lib) defaults to **60 s**; myenergi's own guidance warns the free API may be "limited or removed" if abused and its effective status resolution is ~60 s. 60 s idle / 20 s active stays well under that while keeping the live view responsive during a charge.

## Manual verification

Verified by the maintainer against a live Zappi: idle poll settles at 60 s, drops to 20 s while charging, and the 429 warnings are gone. Refresh failures now log the real code, and the interval backs off on repeated failure.

Backend syntax-checked (`python -m compileall`); both config files parse.

Closes #18