### PR TITLE
Add: per-property graph line mode (step/linear) for the History graph (#20)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,14 @@ Parsed once by `Config` and injected into every service. Keys:
 - `tesla data` — per-field metadata map: `stream_id`, `category`, `unit`, `formula` (sympy
   string or null), `log` (bool), and optional `sleep_default` — the value the field reverts to
   when the vehicle goes to sleep (omit or `null` to leave it at its last reading; the default is
-  a final value, the `formula` is **not** re-applied to it).
+  a final value, the `formula` is **not** re-applied to it). Optional `line_mode` (issue #20) —
+  the History-graph render mode for the field: `"step"` (hold the previous value, then jump — the
+  default when absent; right for sampled/held signals like `VehicleSpeed` or setpoints) or
+  `"linear"` (straight point-to-point line; right for accumulators / continuous quantities like
+  `Odometer`, the energy counters, `OutsideTemp`). Display-only hint handed to the frontend over
+  `TESLA_GRAPH_PROPERTIES`. A field is graphable (appears in the History dropdown) only if
+  `log: true` **and** numeric — set `log: false` to keep a numeric field off the graph (e.g.
+  `GpsHeading`, which wraps 0↔360 and isn't worth graphing).
 - `calculated tesla data` — derived fields (`DrivenToday`, `DrivenThisMonth`): adds
   `source_data_property_id`, `period` (`day`/`month`), `calculation_formula` (e.g. `y - x`).
 - `radioMediaIds` — station name → Nelonen Media id; `defaultRadioStation` — a key from it.
@@ -262,7 +269,7 @@ payload[1..N-1] = type-specific data
 | `0x61` | TESLA_MINUS_TEMP | F→B | (empty) |
 | `0x62` | TESLA_PLUS_TEMP | F→B | (empty) |
 | `0x70` | TESLA_GET_GRAPH_PROPERTIES | F→B | (empty) |
-| `0x71` | TESLA_GRAPH_PROPERTIES | B→F | `count(2B)` + per property `id_len(2B)+id + unit_len(2B)+unit + cat_len(2B)+category` (UTF-8) |
+| `0x71` | TESLA_GRAPH_PROPERTIES | B→F | `count(2B)` + per property `id_len(2B)+id + unit_len(2B)+unit + cat_len(2B)+category + mode_len(2B)+line_mode` (UTF-8); `line_mode` = `step`/`linear` graph render hint |
 | `0x72` | TESLA_GET_HISTORY | F→B | `range_code(1B)` (0=1h,1=1d,2=1M,3=custom,4=1week) + `id_len(2B)+id` + `start_ms(8B)` + `end_ms(8B)` |
 | `0x73` | TESLA_HISTORY | B→F | `id_len(2B)+id` + `status(1B)` + `count(4B)` + count×(`ts_ms(8B)` + `value(8B double)`) |
 | `0x50` | CHARGER_STREAM | B→F | myenergi charger live state: repeated `sub_id(1B) + value` (see charger sub-ids below) |
@@ -689,22 +696,28 @@ a new/renamed service or widget, a protocol change, a build-command change, or a
 invariant. Treat the doc as part of the change, not an afterthought, and bump §7.7.
 
 ### 7.7 Documentation currency
-This guide and `README.md` are current as of the **spot-price cost** work on
-`feature/spot-price-cost` (issue #12), which builds on the charging-stats backend: **hourly Nord Pool
-FI spot pricing** for the Charging view's cost tiles + a live current-price tile. New backend modules
-`charging_service/spot_price.py` (`SpotPriceProvider` — no-key sähkötin.fi fetch/cache/convert, all-in
-`(spot + margin) × (1 + VAT)`, retroactive/historical) and `spot_price_service.py` (`SpotPriceService`
-— hourly `SPOT_PRICE_STREAM` `0x88` broadcast). Cost moved from the `CHARGING_GET_MONTH` handler into
-the loader/session: sessions bucket `ChargeAdded` by UTC hour and price each hour; `month_summary`
-sums session costs + prices the hourly home import (new `read_grid_import_kwh_hourly` +
-`integrate_power_series_hourly`, replacing `read_grid_import_kwh_month`). The flat
-`electricityPriceEurPerKwh` is now a per-hour fallback. `CHARGING_SUMMARY` `0x83` grew to **11 doubles**
-(+`cost_eur`, +`avg_price_eur_per_kwh`); `CHARGING_MONTH` `0x85` unchanged (13 doubles, now spot-valued).
-New `spotPrice` config block. Pure cost math is unit-tested in `backend/tests/test_spot_price.py`.
-Predecessor work — the **charging-stats** backend (`966a04a`; myenergi `CHARGER_STREAM` `0x50`,
-`CHARGING_*`/`CHARGER_HISTORY` `0x80`–`0x87`, per-session energy = **sum of positive `ChargeAdded`
-increments**), the History **empty-window boundary-fill** (`1184b60`/`cc11bb8`), and the `0x70`–`0x73`
-request/response + `(payload, writer)` handler signature (`827824d`) — still applies.
+This guide and `README.md` are current as of the **per-property graph line mode** work on
+`feature/graph-line-mode` (issue #20): a per-property `line_mode` (`step` default / `linear`) that
+tells the shared `HistoryGraph.qml` how to connect a property's consecutive readings — a held step
+for sampled/held signals (`VehicleSpeed`, setpoints) or a straight point-to-point line for
+accumulators / continuous quantities (`Odometer`, energy counters, `OutsideTemp`). Sourced from
+`config.json` `tesla data` metadata (new optional `line_mode` key, read via `prop_cfg.get`),
+threaded through a new `VehicleDataProperty.get_line_mode()`, added to
+`get_graphable_properties`, and serialized as a **4th** per-property field on
+`TESLA_GRAPH_PROPERTIES` `0x71` (`id/unit/category/line_mode`). Frontend: `TeslaHistory::parseProperties`
+reads the 4th field into `History.properties`; `PropertySelector.selectedLineMode` → `HistoryView`
+binds `HistoryGraph.lineMode`; `buildStepped()` and `valueAt()` branch on it (new `buildLinearPath`
++ `interpAt` helpers), and the glow fill / y-fit / live marker follow from those two. Trips and
+Charging inherit the `step` default (their graphs — `VehicleSpeed`, grid/charge power — are sampled),
+so they were untouched. `GpsHeading` was flipped to `log: false` (it wraps 0↔360 and its logged
+history had no consumer — the live map heading reads the live stream, the trip heading is computed
+from Location geometry), removing it from the graphable list and stopping its InfluxDB writes.
+Predecessor work — the **spot-price cost** (`feature/spot-price-cost`, issue #12; `SpotPriceProvider`
++ `SpotPriceService`, `SPOT_PRICE_STREAM` `0x88`, per-hour spot-valued Charging costs, `spotPrice`
+config, `CHARGING_SUMMARY` `0x83` = 11 doubles), the **charging-stats** backend (`966a04a`; myenergi
+`CHARGER_STREAM` `0x50`, `CHARGING_*`/`CHARGER_HISTORY` `0x80`–`0x87`, per-session energy = **sum of
+positive `ChargeAdded` increments**), and the History **empty-window boundary-fill**
+(`1184b60`/`cc11bb8`) — still applies.
 When you land changes that touch behaviour documented here, update this line to the new HEAD commit.
 
 ## 8. Session workflow — main checkout by default, worktree only for parallelism

--- a/backend/src/start_services.py
+++ b/backend/src/start_services.py
@@ -387,7 +387,12 @@ def _register_handlers(
         properties = await vehicle.get_graphable_properties()
         body = struct.pack("!H", len(properties))
         for entry in properties:
-            for field in (entry["id"], entry["unit"] or "", entry["category"] or ""):
+            for field in (
+                entry["id"],
+                entry["unit"] or "",
+                entry["category"] or "",
+                entry["line_mode"] or "step",
+            ):
                 encoded = field.encode("utf-8")
                 body += struct.pack("!H", len(encoded)) + encoded
         await server.send_to(

--- a/backend/src/tesla_service/vehicle.py
+++ b/backend/src/tesla_service/vehicle.py
@@ -68,6 +68,7 @@ class Vehicle:
                 formula=prop_cfg["formula"],
                 log=prop_cfg["log"],
                 sleep_default=prop_cfg.get("sleep_default"),
+                line_mode=prop_cfg.get("line_mode"),
             )
         logger.debug("Loaded %d vehicle data properties", len(self.__data))
 
@@ -457,7 +458,7 @@ class Vehicle:
         omitted until it next updates — the frontend re-requests this list each
         time the view is opened, so it fills in as the session runs.
         Returns:
-            list[dict]: [{"id", "unit", "category"}, ...].
+            list[dict]: [{"id", "unit", "category", "line_mode"}, ...].
         '''
         async with self.__async_lock:
             properties = list(self.__data.values())
@@ -471,6 +472,7 @@ class Vehicle:
                 "id": await data_property.get_id(),
                 "unit": await data_property.get_unit(),
                 "category": await data_property.get_category(),
+                "line_mode": (await data_property.get_line_mode()) or "step",
             })
         result.sort(key=lambda entry: (entry["category"] or "", entry["id"]))
         return result

--- a/backend/src/tesla_service/vehicle_data_property.py
+++ b/backend/src/tesla_service/vehicle_data_property.py
@@ -30,6 +30,7 @@ class VehicleDataProperty:
         formula: str = None,
         log: bool = False,
         sleep_default=None,
+        line_mode: str = None,
     ):
         self.__id = data_id
         self.__stream_id = stream_id
@@ -47,6 +48,12 @@ class VehicleDataProperty:
         # last reading. The default is a FINAL value — the input formula is not
         # re-applied to it. See apply_sleep_default.
         self.__sleep_default = sleep_default
+        # How the History-view graph should connect this field's consecutive readings:
+        # "step" (hold the previous value, then jump — the default, right for sampled/held
+        # signals like VehicleSpeed) or "linear" (straight point-to-point line — right for
+        # accumulators / continuous quantities like Odometer or OutsideTemp). Purely a
+        # display hint handed to the frontend over TESLA_GRAPH_PROPERTIES; None → "step".
+        self.__line_mode = line_mode
         self._async_lock = asyncio.Lock()
         self._vehicle = vehicle
         self.__value_type = None
@@ -312,6 +319,10 @@ class VehicleDataProperty:
     async def get_unit(self):
         async with self._async_lock:
             return self.__unit
+
+    async def get_line_mode(self):
+        async with self._async_lock:
+            return self.__line_mode
 
     async def get_logging(self):
         async with self._async_lock:

--- a/backend/src/utils/protocol.py
+++ b/backend/src/utils/protocol.py
@@ -49,7 +49,7 @@ TESLA_PLUS_TARGET_TEMP = 0x62
 # command bytes above, these are a request/response pair: the backend replies to
 # the requesting client only (server.send_to), never a broadcast.
 TESLA_GET_GRAPH_PROPERTIES = 0x70  # F->B: request the graphable-property list (empty payload)
-TESLA_GRAPH_PROPERTIES = 0x71      # B->F: count(2B) + per property id/unit/category (each len(2B)+UTF-8)
+TESLA_GRAPH_PROPERTIES = 0x71      # B->F: count(2B) + per property id/unit/category/line_mode (each len(2B)+UTF-8); line_mode = "step"|"linear" graph render hint
 TESLA_GET_HISTORY = 0x72           # F->B: range_code(1B) + id(len(2B)+UTF-8) + start_ms(8B) + end_ms(8B)
 TESLA_HISTORY = 0x73               # B->F: id(len(2B)+UTF-8) + status(1B) + count(4B) + count*(ts_ms(8B)+value(8B double))
 

--- a/config_template.json
+++ b/config_template.json
@@ -13,7 +13,8 @@
             "unit": "%",
             "log": true,
             "formula": null,
-            "stream_id": 1
+            "stream_id": 1,
+            "line_mode": "linear"
         },
         "BmsFullchargecomplete": {
             "category": "Charging",
@@ -86,7 +87,8 @@
             "unit": "kWh",
             "log": true,
             "formula": null,
-            "stream_id": 11
+            "stream_id": 11,
+            "line_mode": "linear"
         },
         "EstimatedHoursToChargeTermination": {
             "category": "Charging",
@@ -138,7 +140,8 @@
             "unit": "kWh",
             "log": true,
             "formula": null,
-            "stream_id": 18
+            "stream_id": 18,
+            "line_mode": "linear"
         },
         "Location": {
             "category": "Location",
@@ -159,21 +162,24 @@
             "unit": "km",
             "log": true,
             "formula": "x * 1.609344",
-            "stream_id": 21
+            "stream_id": 21,
+            "line_mode": "linear"
         },
         "OutsideTemp": {
             "category": "Climate",
             "unit": "°C",
             "log": true,
             "formula": null,
-            "stream_id": 22
+            "stream_id": 22,
+            "line_mode": "linear"
         },
         "RatedRange": {
             "category": "Charging",
             "unit": "km",
             "log": true,
             "formula": "x * 1.609344",
-            "stream_id": 23
+            "stream_id": 23,
+            "line_mode": "linear"
         },
         "TimeToFullCharge": {
             "category": "Charging",
@@ -201,7 +207,7 @@
         "GpsHeading": {
             "category": "Driving",
             "unit": null,
-            "log": true,
+            "log": false,
             "formula": null,
             "stream_id": 29
         },
@@ -329,21 +335,24 @@
             "unit": "km",
             "log": true,
             "formula": "x * 1.609344",
-            "stream_id": 45
+            "stream_id": 45,
+            "line_mode": "linear"
         },
         "ACChargingEnergyIn": {
             "category": "Charging",
             "unit": "kWh",
             "log": true,
             "formula": null,
-            "stream_id": 46
+            "stream_id": 46,
+            "line_mode": "linear"
         },
         "DCChargingEnergyIn": {
             "category": "Charging",
             "unit": "kWh",
             "log": true,
             "formula": null,
-            "stream_id": 47
+            "stream_id": 47,
+            "line_mode": "linear"
         }
     },
     "calculated tesla data": {

--- a/frontend_v2/core/tesla/teslahistory.cpp
+++ b/frontend_v2/core/tesla/teslahistory.cpp
@@ -233,8 +233,9 @@ void TeslaHistory::parseProperties(const QByteArray &payload) {
         QString id;
         QString unit;
         QString category;
+        QString lineMode;
         if (!readString(stream, device, id) || !readString(stream, device, unit) ||
-            !readString(stream, device, category)) {
+            !readString(stream, device, category) || !readString(stream, device, lineMode)) {
             logger.warning(QStringLiteral("Truncated graph-properties frame at entry %1").arg(i));
             return;
         }
@@ -242,6 +243,8 @@ void TeslaHistory::parseProperties(const QByteArray &payload) {
         entry.insert(QStringLiteral("id"), id);
         entry.insert(QStringLiteral("unit"), unit);
         entry.insert(QStringLiteral("category"), category);
+        // Graph render hint: "step" (hold-forward, default) or "linear" (point-to-point).
+        entry.insert(QStringLiteral("line_mode"), lineMode);
         properties.append(entry);
     }
 

--- a/frontend_v2/items/history/HistoryGraph.qml
+++ b/frontend_v2/items/history/HistoryGraph.qml
@@ -29,6 +29,15 @@ Item {
 
     property string unit: ""
 
+    // How consecutive readings are connected. "step" (default): hold the previous value
+    // horizontally, then jump — right for sampled / held signals (VehicleSpeed, setpoints)
+    // where telemetry only sends on change and the in-between is unknown. "linear": a
+    // straight point-to-point line — right for accumulators / continuous quantities
+    // (Odometer, energy counters, OutsideTemp) whose value genuinely tracks ~linearly
+    // between readings. Sourced per-property from config.json; buildStepped() and valueAt()
+    // branch on it, and the glow / y-fit / live marker follow from those two.
+    property string lineMode: "step"
+
     // --- Gradient glow under the line (the modern look; tweak here) -----------
     // A translucent area fill under the line that fades to transparent toward the plot
     // floor — the "glow" that makes the graph read as modern instead of a bare stroke.
@@ -85,11 +94,23 @@ Item {
             return []
         const w = a.width, h = a.height
         const x0 = xAxis.min, yTop = yAxis.max
+        // Clamp mapped pixel coordinates to a bounded off-screen range. Points far outside
+        // the visible window (the full-extent endpoints, and any point many view-widths away)
+        // map to enormous pixels when zoomed in tight — and the fill Shape's CurveRenderer
+        // triangulates the WHOLE path (its clip is only a rasteriser scissor, not a geometry
+        // clip), which ASSERTS and aborts the app once a vertex exceeds 2^21 px
+        // (qtriangulator.cpp). LIM sits far off-screen — glowClip scissors it away, and the
+        // in/near-window points that shape the visible fill are never clamped — so the visible
+        // glow is unchanged; it only stops the off-screen tail from blowing past the limit.
+        const LIM = 1 << 15
+        function clamp(v) { return v < -LIM ? -LIM : (v > LIM ? LIM : v) }
+        function px(dx) { return clamp((dx - x0) / xspan * w) }
+        function py(dy) { return clamp((yTop - dy) / yspan * h) }
         const out = []
-        out.push(Qt.point((src[0].x - x0) / xspan * w, h))
+        out.push(Qt.point(px(src[0].x), h))
         for (let i = 0; i < n; ++i)
-            out.push(Qt.point((src[i].x - x0) / xspan * w, (yTop - src[i].y) / yspan * h))
-        out.push(Qt.point((src[n - 1].x - x0) / xspan * w, h))
+            out.push(Qt.point(px(src[i].x), py(src[i].y)))
+        out.push(Qt.point(px(src[n - 1].x), h))
         return out
     }
 
@@ -326,13 +347,14 @@ Item {
             id: series
             width: 2
             color: Theme.accent
-            // Steps are built explicitly in buildStepped() (a horizontal hold then
-            // a vertical jump per reading), so the default straight style renders a
-            // true step. Telemetry only sends a value when it changes, so each
-            // reading holds until the next instead of sloping toward it; building
-            // the path ourselves avoids relying on the renderer's step line style.
-            // (A spline was tried for a smoother look but was reverted: it turned a
-            // genuinely flat/held value into a wobble, misrepresenting the data.)
+            // The path geometry is built explicitly in buildStepped() per the property's
+            // lineMode, so the default straight-segment style renders exactly what we
+            // intend: "step" holds each reading then jumps (telemetry only sends on change,
+            // so a sampled value holds until the next instead of sloping toward it), while
+            // "linear" connects readings point-to-point for accumulators / continuous
+            // signals. Building the path ourselves avoids relying on any renderer line style.
+            // (A smooth spline was tried and reverted: it turned a genuinely flat/held
+            // value into a wobble, misrepresenting the data.)
         }
     }
 
@@ -714,17 +736,23 @@ Item {
         return Qt.formatDateTime(d, "HH:mm:ss")
     }
 
-    // Expand the raw readings into an explicit step path: a horizontal segment at
-    // the held value out to the next timestamp, then a vertical jump to the new
-    // value. Drawn with the straight line style this yields true steps (no slope),
-    // independent of any renderer step support. Data logic still uses the raw
-    // History.points, so the inspect readout and y-fit are unaffected.
+    // Expand the raw readings into an explicit path in DATA coordinates, clamped to the
+    // full extent [lo, hi], per root.lineMode — drawn with the straight line style so the
+    // path geometry we build IS what shows (no reliance on renderer step support). Data
+    // logic still uses the raw pointsData, so the inspect readout and y-fit stay consistent
+    // (valueAt() branches on lineMode the same way).
     function buildStepped(pts) {
         const n = pts.length
         if (n === 0)
             return []
         const lo = root.fullMinX
         const hi = root.fullMaxX
+        if (root.lineMode === "linear")
+            return buildLinearPath(pts, lo, hi)
+        // --- "step" (hold-forward), the default ---
+        // A horizontal segment at the held value out to the next timestamp, then a
+        // vertical jump to the new value — a true step (no slope). Right for sampled /
+        // held signals, whose in-between telemetry never sent is unknown.
         const out = []
         // Value held at the left edge: the y of the last point at or before lo (the
         // boundary the live roller keeps, or the first point), so the line starts
@@ -751,13 +779,65 @@ Item {
         return out
     }
 
-    // Step (hold-forward) lookup: the value at x is that of the most recent point
-    // at or before x. Binary search over the ascending raw series.
+    // "linear" (point-to-point) path in DATA coordinates, clamped to [lo, hi]: an
+    // interpolated point at the left edge, every raw reading strictly inside the window,
+    // then an interpolated point at the right edge. Right for accumulators / continuous
+    // quantities whose value genuinely tracks ~linearly between readings. The edge values
+    // match valueAt()'s "linear" branch (hold at the ends when the edge lies outside the
+    // data), so a value held constant across the window still draws as one flat line —
+    // identical to the step build's boundary-fill case.
+    function buildLinearPath(pts, lo, hi) {
+        const n = pts.length
+        const out = []
+        out.push(Qt.point(lo, interpAt(pts, lo)))
+        for (let i = 0; i < n; ++i) {
+            if (pts[i].x > lo && pts[i].x < hi)
+                out.push(Qt.point(pts[i].x, pts[i].y))
+        }
+        out.push(Qt.point(hi, interpAt(pts, hi)))
+        return out
+    }
+
+    // Linear interpolation of the raw ascending series at time dx: the value on the
+    // straight segment between the two readings bracketing dx, clamped to the endpoints
+    // outside the data range. Binary-searches for the bracketing pair.
+    function interpAt(pts, dx) {
+        const n = pts.length
+        if (n === 0)
+            return NaN
+        if (dx <= pts[0].x)
+            return pts[0].y
+        if (dx >= pts[n - 1].x)
+            return pts[n - 1].y
+        // Largest index with pts[i].x <= dx.
+        let lo = 0
+        let hi = n - 1
+        while (lo < hi) {
+            const mid = (lo + hi + 1) >> 1
+            if (pts[mid].x <= dx)
+                lo = mid
+            else
+                hi = mid - 1
+        }
+        const a = pts[lo]
+        const b = pts[lo + 1]
+        const span = b.x - a.x
+        if (span <= 0)
+            return a.y
+        return a.y + (b.y - a.y) * (dx - a.x) / span
+    }
+
+    // Value at x for the inspect readout, y-fit edge values and the live marker —
+    // consistent with the rendered line. "linear": interpolate between the bracketing
+    // readings. "step" (default): hold-forward — the value of the most recent point at
+    // or before x (binary search over the ascending raw series).
     function valueAt(dx) {
         const pts = root.pointsData
         const n = pts.length
         if (n === 0)
             return NaN
+        if (root.lineMode === "linear")
+            return interpAt(pts, dx)
         if (dx <= pts[0].x)
             return pts[0].y
         if (dx >= pts[n - 1].x)

--- a/frontend_v2/items/history/PropertySelector.qml
+++ b/frontend_v2/items/history/PropertySelector.qml
@@ -25,6 +25,9 @@ ComboBox {
     readonly property var currentEntry:
         (currentIndex >= 0 && model && currentIndex < model.length) ? model[currentIndex] : null
     readonly property string selectedUnit: currentEntry ? (currentEntry.unit || "") : ""
+    // How the graph connects this property's readings: "step" (hold, default) or "linear"
+    // (point-to-point). Sourced from config.json metadata via History.properties.
+    readonly property string selectedLineMode: currentEntry ? (currentEntry.line_mode || "step") : "step"
 
     signal propertySelected(string id)
 

--- a/frontend_v2/views/HistoryView.qml
+++ b/frontend_v2/views/HistoryView.qml
@@ -86,6 +86,10 @@ Rectangle {
             Layout.fillWidth: true
             Layout.fillHeight: true
             unit: propertySelector.selectedUnit
+            // Per-property line render mode (config.json → History.properties). Changing the
+            // selected property always triggers a fresh fetch → reloadFull(), which rebuilds
+            // the path with this mode, so no separate rebuild trigger is needed.
+            lineMode: propertySelector.selectedLineMode
             // Pulsing "now" marker only when this view is showing a genuinely rolling window
             // (live toggle on, not a custom range) — and paused when the view isn't current.
             live: view.isCurrent && view.live && view.rangeCode !== 3


### PR DESCRIPTION
## Summary

Adds a **per-property line-rendering mode** to the shared `HistoryGraph.qml` (issue #20). Every
property was drawn as a held step (`buildStepped()`), which is right for sampled/held signals but
wrong for accumulators and continuous quantities, where the value tracks ~linearly between readings.

A new optional `line_mode` (`"step"` default / `"linear"`) lives in `config.json` `tesla data`
metadata and rides the existing `TESLA_GRAPH_PROPERTIES` (`0x71`) channel to the graph as a 4th
per-property field. `HistoryGraph.buildStepped()` and `valueAt()` branch on it; the glow fill,
y-fit and live marker follow because they derive from those two.

### Mode assignment
- **`linear`** (accumulators / continuous): `Odometer`, `LifetimeEnergyUsed`, `ACChargingEnergyIn`,
  `DCChargingEnergyIn`, `EnergyRemaining`, `BatteryLevel`, `RatedRange`, `EstBatteryRange`,
  `OutsideTemp`.
- **`step`** (default, unchanged): `VehicleSpeed`, `ACChargingPower`, `ChargerVoltage`,
  `ChargeRateMilePerHour`, `ChargeAmps` (setpoint). Trips (`VehicleSpeed`) and Charging (power)
  graphs inherit the `step` default and are untouched.

### Also in this PR
- **`GpsHeading` → `log: false`.** It wraps 0↔360 and its logged history had no consumer (the live
  map heading reads the live stream; the trip heading arrow is computed from `Location` geometry), so
  it's dropped from the graphable dropdown and no longer written to InfluxDB. The live/trip headings
  are unaffected (the broadcast is independent of the `log` flag).
- **Zoom-crash fix (pre-existing, surfaced while testing).** Zooming the graph in far made the
  glow-fill `Shape` (`Shape.CurveRenderer`) triangulate the full-extent endpoints mapped to millions
  of pixels and assert `qAbs(x) < (1 << 21)` in `qtriangulator`, hard-aborting the app. Fixed by
  clamping `glowPolyline`'s mapped pixel coordinates to ±(1<<15) — far off-screen, so the visible
  fill is unchanged. The QtGraphs `LineSeries` renders via GPU geometry (not the triangulator), so
  only the hand-rolled glow Shape was affected.

## Reason

A single held-step render misrepresents accumulators/continuous signals (stairsteps on a value that
really moves continuously). The physically-correct connection between two readings depends on the
signal, so the mode belongs per-property in `config.json` alongside `unit`/`category`/`formula`.

## Files

- **Backend:** `vehicle_data_property.py` (`line_mode` param + `get_line_mode()`), `vehicle.py`
  (load + `get_graphable_properties`), `start_services.py` (serialize 4th field), `protocol.py`
  (format comment), `config_template.json` (+ the gitignored live `config.json`, updated locally).
- **Frontend:** `teslahistory.cpp` (parse 4th field), `PropertySelector.qml` (`selectedLineMode`),
  `HistoryView.qml` (bind `lineMode`), `HistoryGraph.qml` (`lineMode` prop, `buildStepped`/`valueAt`
  branches + `buildLinearPath`/`interpAt` helpers, glow-clamp crash fix).
- **Docs:** `CLAUDE.md` (protocol table, config-key description, §7.7 currency).

## Manual verification

Verified locally by the maintainer (frontend built with `scripts\build-frontend.ps1`):
- History view — `Odometer` / `LifetimeEnergyUsed` / `OutsideTemp` draw point-to-point (smooth
  ramps) with interpolated inspect readouts; `VehicleSpeed` / `ChargeAmps` stay held-step with a
  hold-forward readout. Glow fill, y-axis auto-fit and the live "now" pulse sit correctly in both
  modes. `GpsHeading` no longer appears in the dropdown.
- Zoomed the graph all the way in — no crash (previously aborted with the qtriangulator assert);
  the glow fill stays correct at every zoom level.
- Backend: `python -m compileall backend/src` clean; both config JSON files parse.

Closes #20
