### PR TITLE
Fix: Trips dropdown white-map-tile artifact (#9) + clipped labels (#19)

### DIFF
--- a/frontend_v2/app/Theme.qml
+++ b/frontend_v2/app/Theme.qml
@@ -105,6 +105,10 @@ QtObject {
     readonly property color tripComboBg: "#662c2c2c"
     readonly property color tripComboPressed: "#992c2c2c"
     readonly property color tripComboPopupBg: "#f2242424"
+    // Opaque non-hover row background (the popup bg sans alpha). Kept opaque so a hover
+    // only recolours the row's node instead of adding/removing one — the node churn is
+    // what triggered the white-map-tile re-batch artifact (issue #9).
+    readonly property color tripComboRowBg: "#242424"
     readonly property color tripComboHover: "#5c5c5c"
     // Start/end route markers: a map-red so they read as pins, distinct from the
     // green→red speed gradient of the route line (the pin shape disambiguates).

--- a/frontend_v2/items/trip/TripComboBox.qml
+++ b/frontend_v2/items/trip/TripComboBox.qml
@@ -37,20 +37,34 @@ ComboBox {
 
     contentItem: Text {
         leftPadding: 12
-        rightPadding: control.indicator ? control.indicator.width + 12 : 12
+        // The control's Basic-style rightPadding already reserves the indicator's width
+        // (the template places the contentItem inside it), so pad only the 12px gap —
+        // adding indicator.width here too double-counted it and cut the collapsed
+        // label off ~30px early.
+        rightPadding: 12
         text: control.displayText
         font: control.font
         color: Theme.dataLabelValue
         verticalAlignment: Text.AlignVCenter
         wrapMode: Text.WordWrap
-        maximumLineCount: 2
         elide: Text.ElideRight
+        // Shrink-before-elide, constrained by the item HEIGHT (52px ≈ two lines), not
+        // maximumLineCount: the Text.Fit search only shrinks on physical overflow — a
+        // maximumLineCount truncation elides at full size without ever trying a smaller
+        // font (qquicktext.cpp fit loop) — so the label shrinks (≥12px) until it all
+        // fits and elides only below the minimum.
+        fontSizeMode: Text.Fit
+        minimumPixelSize: 12
     }
 
     delegate: ItemDelegate {
         id: entryDelegate
         width: ListView.view ? ListView.view.width : control.width
         height: 52
+        // The Basic style's default padding (12) left the row text only 28px of height —
+        // one line — so elide+wrap cut the label instead of wrapping it (issue #19). Zero
+        // padding hands the Text the full 52px, enough for two lines.
+        padding: 0
         required property int index
         required property var modelData
         // Hover / keyboard highlight (NOT the white default) — this is the fix.
@@ -60,15 +74,18 @@ ComboBox {
             color: entryDelegate.highlighted ? Theme.tripComboHover : "transparent"
         }
         contentItem: Text {
-            leftPadding: 8
-            rightPadding: 8
+            leftPadding: 12
+            rightPadding: 12
             text: control.formatEntry(entryDelegate.modelData)
             font: control.font
             color: Theme.dataLabelValue
             verticalAlignment: Text.AlignVCenter
             wrapMode: Text.WordWrap
-            maximumLineCount: 2
+            // Height-constrained like the field text (no maximumLineCount) so Text.Fit
+            // can actually shrink instead of eliding — see the contentItem note above.
             elide: Text.ElideRight
+            fontSizeMode: Text.Fit
+            minimumPixelSize: 12
         }
     }
 

--- a/frontend_v2/items/trip/TripComboBox.qml
+++ b/frontend_v2/items/trip/TripComboBox.qml
@@ -69,9 +69,12 @@ ComboBox {
         required property var modelData
         // Hover / keyboard highlight (NOT the white default) — this is the fix.
         highlighted: control.highlightedIndex === index
+        // Always-opaque, always-present background: hovering only recolours an existing
+        // node. Toggling transparent<->opaque added/removed a node, and that re-batch is
+        // what flipped map tiles white underneath (issue #9, QTBUG-67169).
         background: Rectangle {
             radius: 6
-            color: entryDelegate.highlighted ? Theme.tripComboHover : "transparent"
+            color: entryDelegate.highlighted ? Theme.tripComboHover : Theme.tripComboRowBg
         }
         contentItem: Text {
             leftPadding: 12

--- a/frontend_v2/items/trip/TripMap.qml
+++ b/frontend_v2/items/trip/TripMap.qml
@@ -66,6 +66,10 @@ Item {
         id: map
         anchors.fill: parent
         plugin: osmPlugin
+        // QTBUG-62463/67169: hovering a popup/menu over a Map re-batches the scene and
+        // mis-batches the tile quads — random tiles draw as solid white. Opacity < 1
+        // forces the map subtree through the alpha pass, keeping its batching consistent.
+        opacity: 0.99
         copyrightsVisible: false
         zoomLevel: root.defaultZoom
         bearing: 0

--- a/frontend_v2/items/trip/TripSelector.qml
+++ b/frontend_v2/items/trip/TripSelector.qml
@@ -38,7 +38,7 @@ TripComboBox {
                  + pad(s.getHours()) + ":" + pad(s.getMinutes()) + "–"
                  + pad(e.getHours()) + ":" + pad(e.getMinutes())
         if (!isNaN(entry.distanceKm))
-            text += "  ·  " + entry.distanceKm.toFixed(1) + " km"
+            text += " · " + entry.distanceKm.toFixed(1) + " km"
         return text
     }
 

--- a/frontend_v2/items/trip/WeekSelector.qml
+++ b/frontend_v2/items/trip/WeekSelector.qml
@@ -51,7 +51,7 @@ TripComboBox {
                                               : Trips.weekCounts[String(startMs)]
         if (c === undefined)
             return ""
-        return "  ·  " + c + " " + (c === 1 ? qsTr("matka") : qsTr("matkaa"))
+        return " · " + c + " " + (c === 1 ? qsTr("matka") : qsTr("matkaa"))
     }
 
     // The week windows (start/end ms) computed fresh from the current date.


### PR DESCRIPTION
## Summary

Fixes the two open Trips-view dropdown bugs:

- **#9 — white rectangle over the map when hovering dropdown entries.** The dropdowns and the map share the window's scene-graph batch renderer: hovering a row toggled the delegate background between `transparent` and a colour, adding/removing a render node, and the forced re-batch mis-batches QtLocation's textured tile quads (known Qt bug family QTBUG-62463 / QTBUG-67169 / QTBUG-82185 — "white/gray rectangles on Map, flickering as menu items are hovered"), drawing a random tile as a solid white quad. Fixed with two zero-visual-cost changes: `opacity: 0.99` on the `Map` (the canonical Qt workaround — the map subtree renders in the alpha pass, keeping its batching consistent) and an always-opaque delegate row background (new `Theme.tripComboRowBg`, the popup bg sans alpha) so hovering only recolours an existing node instead of triggering a re-batch at all.
- **#19 — dropdown labels clipped instead of wrapping to two lines.** Three stacked causes: (1) the Basic style's `ItemDelegate` default `padding: 12` left the 52px rows only 28px of text height — one line — and `elide`+`wrapMode` elides at the last line that fits *the height*, so rows never wrapped; (2) the collapsed field double-counted the indicator width (the control's Basic-style `rightPadding` already reserves it), clipping the selected label ~30px early; (3) `maximumLineCount` defeated the `Text.Fit` shrink search (per `qquicktext.cpp`, the fit loop only shrinks on physical overflow — a `maximumLineCount` truncation elides at full size). Fixed with `padding: 0` on the delegate, indicator-aware padding removed from the field text, tightened `" · "` separators, and height-constrained `fontSizeMode: Text.Fit` (`minimumPixelSize: 12`) so labels shrink before ever eliding.

## Changes

- `frontend_v2/items/trip/TripComboBox.qml` — delegate padding/background, field padding, height-constrained shrink-before-elide on both texts
- `frontend_v2/items/trip/TripMap.qml` — `opacity: 0.99` on the `Map`
- `frontend_v2/app/Theme.qml` — new `tripComboRowBg` colour
- `frontend_v2/items/trip/WeekSelector.qml`, `TripSelector.qml` — tighter `" · "` label separators

## Manual verification (done on the dev machine)

1. Matkat view → open the week/trip dropdowns → sweep the pointer over all rows, slow and fast, and scroll the list: no white/gray tile appears on the map; the hover highlight stays the muted grey.
2. Week field + rows show the full `Tämä viikko · 13.7.–19.7. · N matkaa` label (wrapping to two lines); trip field + rows show the full time range and `· X.X km` distance — including in the collapsed fields.
3. Regression pass: week/trip selection, route drawing, pan/zoom and the graph-inspect arrow all behave as before.

Before-screenshots are attached to the issues (#9, #19).

Fixes #9
Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tYsjPMzewb7pXD774XHeb