### PR TITLE
Fix: WeatherService permanently deadlocked on a stalled FMI response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -448,6 +448,25 @@ needed). `__fetch_observation` walks observation slots newest→oldest and uses 
 with a valid air-temperature reading (avoiding the all-NaN padding slots fmiopendata returns).
 **Talks to:** FMI open data, `Server`.
 
+> **Load-bearing invariants — do not break:**
+> - **Never call `fmiopendata.wfs.download_stored_query`.** Its fetch helper is `requests.get(url)`
+>   with **no timeout** and no way to pass one. A stalled FMI response (connection accepted, partial
+>   body, then silence — no FIN/RST) parks the caller in `read()` *forever*; in production that burned
+>   an executor thread and killed weather for 16 days. `__download_stored_query` +
+>   `__fetch_and_parse` replace it: the same URL (`STORED_QUERY_URL + query_id`, args as aiohttp
+>   `params` so non-ASCII places like `Ryttylä` percent-encode) fetched with an explicit
+>   `_FMI_TIMEOUT`, then handed to fmiopendata's own `MultiPoint` parser in an executor. Any failure
+>   logs a WARNING and returns `None`. An `asyncio.wait_for(_FETCH_DEADLINE_SECONDS)` wraps both.
+> - **Keep `max_instances` ≥ 2 + a real `misfire_grace_time` on the refresh job.** APScheduler's
+>   default `max_instances=1` turns one wedged run into a permanent outage — every later tick is
+>   refused with *"skipped: maximum number of running instances reached (1)"*.
+> - **Schedule the job before the initial fetch** in `run()`, so a failed/slow first fetch can't
+>   leave the service with no periodic refresh at all.
+> - **A cycle with no future forecast hours is a failed cycle** — return without broadcasting or
+>   caching. The frontend replaces its whole forecast model per frame, so a banner-only frame blanks
+>   all five cards *and* poisons `__last_forecast` for every later reconnect. Stale-but-complete
+>   beats half-blank.
+
 #### 5.2.5 `influxdb_service/influxdb_handler.py`
 `InfluxDBHandler` wraps the async InfluxDB client: `write_tesla_data` (logged fields + midnight
 snapshot), `read_first_value_day`/`_month` (calculated-field baselines), `read_tesla_data_property`
@@ -696,7 +715,17 @@ a new/renamed service or widget, a protocol change, a build-command change, or a
 invariant. Treat the doc as part of the change, not an afterthought, and bump §7.7.
 
 ### 7.7 Documentation currency
-This guide and `README.md` are current as of the **per-property graph line mode** work on
+This guide is current as of the **weather-service hang fix**: `WeatherService` had deadlocked on the
+Pi for 16 days (widget empty, rest of the backend healthy). `fmiopendata`'s fetch helper calls
+`requests.get()` with no timeout, so a stalled FMI response parked an executor thread forever, and
+APScheduler's default `max_instances=1` then refused every later tick. Fixed in three layers, all
+inside `backend/src` (no new dependencies): the FMI GET is now issued directly with aiohttp +
+`_FMI_TIMEOUT` and parsed with fmiopendata's own `MultiPoint` (`__download_stored_query` /
+`__fetch_and_parse`) under an `asyncio.wait_for` deadline; the refresh job gained
+`max_instances=2` / `misfire_grace_time=300` / `coalesce=True` and is now scheduled *before* the
+initial fetch; and a cycle yielding no future forecast hours returns without broadcasting or caching
+(a banner-only frame blanked the frontend's five cards permanently — see §5.2.4's invariants).
+Predecessor work — this guide and `README.md` are current as of the **per-property graph line mode** work on
 `feature/graph-line-mode` (issue #20): a per-property `line_mode` (`step` default / `linear`) that
 tells the shared `HistoryGraph.qml` how to connect a property's consecutive readings — a held step
 for sampled/held signals (`VehicleSpeed`, setpoints) or a straight point-to-point line for

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,13 @@ Required secrets/paths, loaded by `utils/config_parser.get_env`:
 
 `start_services.main()` fails fast if any of these are missing. **Optional:** `MYENERGI_HUB_SERIAL`
 / `MYENERGI_API_KEY` (myenergi cloud digest-auth creds) — absent → the charger service is skipped
-and the rest of the stack still runs.
+and the rest of the stack still runs. Also optional: `TESLA_HOMEDASH_LOG_LEVEL` —
+`debug`/`info`/`warning`/`error`/`critical`, **default `info`** (invalid → `info` + a warning),
+mirroring the frontend variable of the same name. Read by `configure_logging()`, which calls
+`load_dotenv()` itself because `get_env`'s lazy load happens after logging is set up; a real
+environment variable (systemd `Environment=`) still wins over `.env`. **Keep the deployment at
+`info`** — `debug` logs a line per telemetry property and rotates the Pi's journal fast enough to
+destroy incident history.
 
 ### `config.json` (copy from `config_template.json`)
 Parsed once by `Config` and injected into every service. Keys:
@@ -488,7 +494,8 @@ guards; they're the only thing preventing injection if non-config input ever rea
 - **`config_parser.py`**: `Config` validates + exposes `config.json`; `get_env` loads `.env` once.
 - **`protocol.py`**: every message-type byte, weather sub-id, `MAX_MSG_SIZE`, and `frame()`. The
   single source of truth — add new constants here, never on a class.
-- **`logger_configurator.py`**: `configure_logging` wires the shared stdout formatter
+- **`logger_configurator.py`**: `configure_logging(level=None)` resolves the level from
+  `TESLA_HOMEDASH_LOG_LEVEL` (default **INFO**, not DEBUG) and wires the shared stdout formatter
   (`LEVEL | YYYY-MM-DD | HH:MM:SS | name | message`) onto an allow-list of top-level loggers.
   **Every service's logger prefix must be in `_SERVICE_LOGGERS`** (`tesla_service`, `media_service`,
   `weather_service`, `influxdb_service`, `charging_service`, `myenergi_service`, `trip_service`,
@@ -724,7 +731,9 @@ inside `backend/src` (no new dependencies): the FMI GET is now issued directly w
 `__fetch_and_parse`) under an `asyncio.wait_for` deadline; the refresh job gained
 `max_instances=2` / `misfire_grace_time=300` / `coalesce=True` and is now scheduled *before* the
 initial fetch; and a cycle yielding no future forecast hours returns without broadcasting or caching
-(a banner-only frame blanked the frontend's five cards permanently — see §5.2.4's invariants).
+(a banner-only frame blanked the frontend's five cards permanently — see §5.2.4's invariants). Also
+`configure_logging` is now env-driven via `TESLA_HOMEDASH_LOG_LEVEL`, defaulting to **INFO** instead
+of the hardcoded DEBUG that was rotating the Pi's journal too fast for forensics.
 Predecessor work — this guide and `README.md` are current as of the **per-property graph line mode** work on
 `feature/graph-line-mode` (issue #20): a per-property `line_mode` (`step` default / `linear`) that
 tells the shared `HistoryGraph.qml` how to connect a property's consecutive readings — a held step

--- a/backend/src/utils/logger_configurator.py
+++ b/backend/src/utils/logger_configurator.py
@@ -1,4 +1,7 @@
 import logging
+import os
+
+from dotenv import load_dotenv
 
 # ── Logger name constants ─────────────────────────────────────────────────────
 
@@ -32,13 +35,55 @@ _SERVICE_LOGGERS = (
 )
 
 
-def configure_logging(level: int = logging.DEBUG) -> None:
+_LOG_LEVEL_ENV = "TESLA_HOMEDASH_LOG_LEVEL"
+
+_LEVEL_NAMES = {
+    "debug": logging.DEBUG,
+    "info": logging.INFO,
+    "warning": logging.WARNING,
+    "error": logging.ERROR,
+    "critical": logging.CRITICAL,
+}
+
+_DEFAULT_LEVEL = logging.INFO
+
+
+def _resolve_level() -> tuple[int, str | None]:
+    '''
+    Reads the log level from TESLA_HOMEDASH_LOG_LEVEL, mirroring the frontend's
+    variable of the same name.  Returns the level plus the offending string when
+    the value was unrecognised, so the caller can warn once handlers exist.
+    Unset or invalid falls back to INFO — DEBUG emits a line per telemetry
+    property, which on the embedded deployment rotates the systemd journal fast
+    enough to destroy incident history.
+    '''
+    raw = os.getenv(_LOG_LEVEL_ENV)
+    if raw is None:
+        return _DEFAULT_LEVEL, None
+    level = _LEVEL_NAMES.get(raw.strip().lower())
+    if level is None:
+        return _DEFAULT_LEVEL, raw
+    return level, None
+
+
+def configure_logging(level: int | None = None) -> None:
     '''
     Configures all service loggers with a shared StreamHandler and formatter.
     Must be called once at application startup before any service is initialised.
     Arguments:
-        level (int): Minimum log level for all service loggers (default: DEBUG).
+        level (int): Minimum log level for all service loggers.  When None (the
+            default) the level comes from TESLA_HOMEDASH_LOG_LEVEL, falling back
+            to INFO.
     '''
+    invalid: str | None = None
+    if level is None:
+        # `.env` is normally loaded lazily by config_parser.get_env, whose first
+        # call happens *after* logging is configured — so load it here too.
+        # load_dotenv is idempotent and does not override real env vars, which is
+        # what lets systemd's Environment= win over a stale `.env` on the Pi.
+        load_dotenv()
+        level, invalid = _resolve_level()
+
     formatter = logging.Formatter(fmt=_LOG_FORMAT, datefmt=_DATE_FORMAT)
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
@@ -52,3 +97,11 @@ def configure_logging(level: int = logging.DEBUG) -> None:
             logger.addHandler(handler)
         # Do not propagate to the root logger — each service logger is self-contained.
         logger.propagate = False
+
+    # Warn only now that the handlers exist, so the message is formatted like
+    # every other log line instead of hitting logging's lastResort handler.
+    if invalid is not None:
+        logging.getLogger(UTILS).warning(
+            "Invalid %s=%r; falling back to INFO (valid: %s)",
+            _LOG_LEVEL_ENV, invalid, ", ".join(_LEVEL_NAMES),
+        )

--- a/backend/src/weather_service/weather_service.py
+++ b/backend/src/weather_service/weather_service.py
@@ -7,15 +7,45 @@ import struct
 from datetime import datetime, timezone, timedelta
 from zoneinfo import ZoneInfo
 
+from xml.etree.ElementTree import ParseError
+
+import aiohttp
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
-from fmiopendata.wfs import download_stored_query
+from fmiopendata.multipoint import MultiPoint
+from fmiopendata.wfs import STORED_QUERY_URL
 
 from ..server.server import Server
 from ..utils import protocol
 from ..utils.config_parser import Config
 
 logger = logging.getLogger("weather_service.weather_service")
+
+# Hard per-request ceiling on an FMI WFS fetch.  fmiopendata's own helper
+# (`wfs.download_stored_query` → `utils.read_url`) calls `requests.get(url)` with
+# NO timeout and exposes no way to pass one, and nothing here sets
+# socket.setdefaulttimeout.  A server that accepts the connection, sends a
+# partial body and then goes silent — no FIN, no RST — therefore parks the caller
+# in read() forever.  That happened in production: the socket sat ESTABLISHED for
+# 16 days, permanently burning an executor thread and (via max_instances=1)
+# gating every later run of the refresh job, so weather silently stopped
+# updating while the rest of the backend stayed healthy.  We now issue the GET
+# ourselves so the timeout is enforced at the socket layer.
+_FMI_TIMEOUT = aiohttp.ClientTimeout(total=30, sock_connect=10, sock_read=20)
+
+# Belt-and-braces deadline around the whole fetch-and-parse coroutine, covering
+# anything _FMI_TIMEOUT does not (e.g. a pathological XML parse).  Must exceed
+# _FMI_TIMEOUT.total so a genuine network timeout reports as such.
+_FETCH_DEADLINE_SECONDS = 45
+
+# Scheduler resilience.  APScheduler's default max_instances=1 means a single
+# run that never returns refuses every subsequent tick for the process lifetime
+# ('skipped: maximum number of running instances reached (1)').  Allowing a
+# second concurrent instance keeps the schedule alive even if one run wedges;
+# the grace time stops a briefly busy event loop from dropping a tick as a
+# misfire (the APScheduler default is 1 second).
+_JOB_MAX_INSTANCES = 2
+_MISFIRE_GRACE_SECONDS = 300
 
 
 class ForecastMeasurement:
@@ -139,13 +169,21 @@ class WeatherService:
         every 15 minutes.
         '''
         logger.info("Weather service starting: place=%s", self.__place)
-        logger.info("Performing initial weather fetch")
-        await self.__update_forecast()
+        # Schedule BEFORE the initial fetch: the periodic refresh must exist even
+        # if the first fetch fails or runs long, otherwise a bad start leaves the
+        # service with no job at all and weather never recovers.  Overlapping the
+        # initial fetch with a cron tick is harmless — _JOB_MAX_INSTANCES allows
+        # it and a broadcast is idempotent.
         self.__scheduler.start()
         self.__scheduler.add_job(
             func=self.__update_forecast,
             trigger=CronTrigger(hour="*", minute="0,15,30,45", timezone=self.__zone_info),
+            max_instances=_JOB_MAX_INSTANCES,
+            misfire_grace_time=_MISFIRE_GRACE_SECONDS,
+            coalesce=True,
         )
+        logger.info("Performing initial weather fetch")
+        await self.__update_forecast()
 
     def get_run_task(self) -> asyncio.Task:
         '''
@@ -186,6 +224,21 @@ class WeatherService:
             for key in ("Precipitation amount", "Total cloud cover"):
                 observation.set_measurement(key, current_forecast.get_measurement(key))
 
+        # A cycle with no future hours is a FAILED cycle, not a partial one: the
+        # frontend replaces its whole forecast model per frame, so broadcasting a
+        # banner-only frame blanks all five forecast cards until the next good
+        # frame — and caches that blanked frame for every client that reconnects
+        # afterwards.  Keeping the previous frame degrades to stale-but-complete
+        # instead, and the warning makes an otherwise silent dead cycle visible.
+        if not future_hours:
+            logger.warning(
+                "Weather cycle produced no forecast hours (observation=%s, "
+                "forecast rows=%d) — keeping the previous frame",
+                "ok" if observation is not None else "missing",
+                len(forecast_hours),
+            )
+            return
+
         forecasts: list[ForecastHour] = []
         if observation is not None:
             forecasts.append(observation)
@@ -194,13 +247,68 @@ class WeatherService:
             forecasts.append(current_forecast)
         forecasts.extend(future_hours)
 
-        if forecasts:
-            logger.info("Broadcasting weather forecast to clients")
-            stream_data = await self.__get_stream_data(forecasts)
-            self.__last_forecast = protocol.frame(
-                protocol.WEATHER_FORECAST, b"".join(stream_data)
+        logger.info("Broadcasting weather forecast to clients")
+        stream_data = await self.__get_stream_data(forecasts)
+        self.__last_forecast = protocol.frame(
+            protocol.WEATHER_FORECAST, b"".join(stream_data)
+        )
+        await self.__server.broadcast(self.__last_forecast)
+
+    async def __download_stored_query(
+        self, query_id: str, params: dict[str, str], label: str
+    ):
+        '''
+        Downloads and parses an FMI WFS stored query, replacing
+        fmiopendata.wfs.download_stored_query so a socket-level timeout can be
+        enforced (see _FMI_TIMEOUT).  Returns a fmiopendata MultiPoint, or None
+        when the request or the parse fails — every failure is logged and
+        swallowed so one bad cycle never wedges the refresh job.
+
+        The URL is built exactly as fmiopendata builds it (STORED_QUERY_URL +
+        query_id + query args); passing the args as aiohttp params percent-encodes
+        non-ASCII place names (e.g. Ryttylä), which is what requests did for
+        fmiopendata implicitly.
+        Arguments:
+            query_id (str): FMI stored query id.
+            params (dict[str, str]): Query arguments (starttime/endtime/place).
+            label (str): Human-readable query name used in log messages.
+        '''
+        try:
+            return await asyncio.wait_for(
+                self.__fetch_and_parse(query_id, params), _FETCH_DEADLINE_SECONDS
             )
-            await self.__server.broadcast(self.__last_forecast)
+        except asyncio.TimeoutError:
+            # Must precede the OSError clause: on Python 3.11+ asyncio.TimeoutError
+            # is the builtin TimeoutError, which is an OSError subclass.
+            logger.warning(
+                "FMI %s fetch timed out for place=%s (deadline %ds)",
+                label, self.__place, _FETCH_DEADLINE_SECONDS,
+            )
+            return None
+        except (aiohttp.ClientError, OSError, ParseError, ValueError, KeyError, IndexError) as e:
+            # ClientError/OSError → network + HTTP failures; ParseError/ValueError →
+            # malformed or defused XML; KeyError/IndexError → unexpected response shape.
+            logger.warning(
+                "FMI %s fetch failed for place=%s: %s: %s",
+                label, self.__place, type(e).__name__, e,
+            )
+            return None
+
+    async def __fetch_and_parse(self, query_id: str, params: dict[str, str]):
+        '''
+        Performs one FMI WFS request and parses the response.  Raises on any
+        failure; __download_stored_query owns the error handling.
+        Arguments:
+            query_id (str): FMI stored query id.
+            params (dict[str, str]): Query arguments (starttime/endtime/place).
+        '''
+        async with aiohttp.ClientSession(timeout=_FMI_TIMEOUT) as session:
+            async with session.get(STORED_QUERY_URL + query_id, params=params) as response:
+                response.raise_for_status()
+                xml = await response.read()
+        # The XML parse is pure CPU and always terminates, but it is heavy enough
+        # (numpy-backed) to keep off the event loop.
+        return await self.__loop.run_in_executor(None, MultiPoint, xml, query_id)
 
     async def stream_everything(self, client) -> None:
         '''
@@ -228,28 +336,17 @@ class WeatherService:
         start_str = current_hour_start.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
         end_str = end_time.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
-        try:
-            # NOTE: confirmed stored query for 10-minute surface weather
-            # observations; returns air temp, wind speed, precipitation, cloud cover.
-            data = await self.__loop.run_in_executor(
-                None,
-                lambda: download_stored_query(
-                    query_id="fmi::observations::weather::multipointcoverage",
-                    args=[
-                        f"starttime={start_str}",
-                        f"endtime={end_str}",
-                        f"place={self.__place}",
-                    ],
-                ),
-            )
-        except (OSError, ValueError, KeyError) as e:
-            # OSError covers network/HTTP failures from fmiopendata's urllib layer;
-            # ValueError/KeyError catch malformed XML and unexpected response shapes.
-            logger.warning(
-                "FMI observation fetch failed for place=%s: %s: %s",
-                self.__place, type(e).__name__, e,
-            )
-            return None
+        # NOTE: confirmed stored query for 10-minute surface weather
+        # observations; returns air temp, wind speed, precipitation, cloud cover.
+        data = await self.__download_stored_query(
+            query_id="fmi::observations::weather::multipointcoverage",
+            params={
+                "starttime": start_str,
+                "endtime": end_str,
+                "place": self.__place,
+            },
+            label="observation",
+        )
 
         if not data or not data.data:
             return None
@@ -324,24 +421,15 @@ class WeatherService:
         start_str = current_hour.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
         end_str = end_time.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
-        try:
-            data = await self.__loop.run_in_executor(
-                None,
-                lambda: download_stored_query(
-                    query_id="fmi::forecast::harmonie::surface::point::multipointcoverage",
-                    args=[
-                        f"starttime={start_str}",
-                        f"endtime={end_str}",
-                        f"place={self.__place}",
-                    ],
-                ),
-            )
-        except (OSError, ValueError, KeyError) as e:
-            logger.warning(
-                "FMI forecast fetch failed for place=%s: %s: %s",
-                self.__place, type(e).__name__, e,
-            )
-            return []
+        data = await self.__download_stored_query(
+            query_id="fmi::forecast::harmonie::surface::point::multipointcoverage",
+            params={
+                "starttime": start_str,
+                "endtime": end_str,
+                "place": self.__place,
+            },
+            label="forecast",
+        )
 
         if not data or not data.data:
             return []


### PR DESCRIPTION
## Summary

The weather widget on the Pi went blank and no forecast was broadcast for **16 days**, while telemetry, media and InfluxDB writes all stayed healthy. This fixes the deadlock in three independent layers, plus a related bug that made the failure look worse in the UI than it was.

All changes are in `backend/src` — **no new dependencies**, no patching of `site-packages`, no config or deployment changes required. `aiohttp` and `python-dotenv` were already dependencies, and fmiopendata's own parser class is reused rather than modified.

## Why

Root cause chain, confirmed with direct evidence from the stuck process (backend PID 1716, uptime 24 days):

1. `fmiopendata`'s fetch helper is `requests.get(url)` with **no timeout**, and `download_stored_query` exposes no way to pass one. Nothing set `socket.setdefaulttimeout` either.
2. FMI accepted the TCP connection, sent ~5.5 KB of a response, then went silent — no FIN, no RST. With no read timeout the socket stayed `ESTABLISHED` forever and the executor thread parked in `read()` indefinitely.
3. `await run_in_executor(...)` therefore never returned, so that job instance never completed.
4. APScheduler's default `max_instances=1` then refused **every** subsequent 15-minute tick — `skipped: maximum number of running instances reached (1)` — for the rest of the process lifetime.

Live evidence: thread `asyncio_2` blocked in syscall 63 (`read()`) on fd 22 → `193.166.221.39:443` (opendata.fmi.fi); `ss -tni` reporting `ESTAB`, `bytes_received:5535` (truncated mid-response), `lastrcv` ≈ 16.2 days. FMI itself was healthy throughout — this was a one-off stalled response with no way to time out. Only one executor thread was burned, which is why every other `run_in_executor` path kept working and only weather was dead.

## Changes

**1. Socket-level timeout — the real fix** (`weather_service.py`)

Stop calling `download_stored_query`. New `__download_stored_query` / `__fetch_and_parse` issue the same WFS GET with aiohttp under an explicit `_FMI_TIMEOUT` (total 30s, sock_connect 10, sock_read 20), then hand the bytes to fmiopendata's own `MultiPoint` parser in an executor.

Because the network leg is now async, **no thread can be parked at all** — leaked threads can no longer accumulate one per incident, which a bare `socket.setdefaulttimeout` would not have prevented as cleanly (and would have applied process-wide to every other socket).

Query args are passed as aiohttp `params` so the non-ASCII place name still percent-encodes exactly as `requests` did for fmiopendata (`place=Ryttyl%C3%A4`).

**2. asyncio-level deadline** (`weather_service.py`)

`asyncio.wait_for(_FETCH_DEADLINE_SECONDS)` wraps fetch+parse as a backstop. The `TimeoutError` clause deliberately precedes the `OSError` one: on Python 3.11+ `asyncio.TimeoutError` *is* the builtin `TimeoutError`, an `OSError` subclass, so the reverse order would misreport timeouts.

**3. Scheduler resilience** (`weather_service.py`)

`max_instances=2`, `misfire_grace_time=300`, `coalesce=True`. The job is also now added **before** the initial fetch, so a failed or slow first fetch can no longer leave the service with no periodic refresh at all.

**4. Banner-only frames no longer blank the forecast cards** (`weather_service.py`)

Found while confirming why the widget was *empty* rather than showing frozen 2026-07-31 values. `weatherdata.cpp:117` replaces the whole forecast model per frame (`setRows`) and `MainWeather.qml:29` is a bare `Repeater` over it — so a frame carrying only the observation row (observation OK, forecast fetch failed) **deletes all five forecast cards** *and* is cached as `__last_forecast` for every later reconnect. With the job deadlocked, nothing could ever undo it.

A cycle producing no future forecast hours is now treated as a failed cycle: no broadcast, no cache overwrite, and a WARNING naming which leg failed. Stale-but-complete beats half-blank, and a dead cycle is no longer silent at INFO.

**5. Configurable backend log level** (`logger_configurator.py`)

`configure_logging()` was hardcoded to `logging.DEBUG` with no override short of editing the source. On the Pi, per-property telemetry logging rotated the journal fast enough that only ~8 hours were retained — which is why the 2026-07-31 onset of this incident is unrecoverable.

The level now comes from `TESLA_HOMEDASH_LOG_LEVEL` (mirroring the frontend variable and its values), **defaulting to INFO**. Invalid values fall back to INFO and warn *after* handlers are installed, so the warning is formatted like every other log line. `configure_logging()` calls `load_dotenv()` itself because `get_env`'s lazy load happens after logging is configured; it is idempotent and does not override real env vars, so systemd's `Environment=` still wins over a stale `.env`.

## Manual verification

No UI changes, so no screenshots. Backend verified directly:

- `python -m compileall backend/src` — clean.
- **Live FMI fetch**: the aiohttp path returns identical timestamps and values to `download_stored_query` for both stored queries (observation + harmonie forecast), with `Ryttylä` correctly encoded.
- **Reproduced the exact production failure** with a fake server that accepts, sends a partial body, then holds the socket open forever: the fetch now returns `None` after ~2s and logs `FMI observation fetch timed out for place=Ryttylä`, instead of hanging.
- **Cache integrity**: a fully-failed cycle preserves `__last_forecast` and broadcasts nothing.
- **Happy path**: a live cycle fetches 8 hours and broadcasts one frame (banner + 7 rows).
- APScheduler 3.11.2 confirmed to accept the new job kwargs (`max_instances` / `misfire_grace_time` / `coalesce`).

Worth watching after deploy: the `Broadcasting weather forecast to clients` line should appear every 15 minutes, and any FMI trouble should now surface as a `WARNING` rather than silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
