### PR TITLE
Claude Code tooling: Python/QML pre-build hook + agent-builds-frontend policy

### DIFF
--- a/.claude/hooks/check-edit.py
+++ b/.claude/hooks/check-edit.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+'''
+PostToolUse hook: validate an edited file before the agent moves on.
+
+Claude Code passes the tool invocation as JSON on stdin. This reads the edited
+file path and dispatches to the cheapest check that can catch a build-breaking
+mistake without a full build:
+
+    backend/src/**.py -> python -m compileall backend/src   (CLAUDE.md 3.3)
+    **.qml            -> qmllint, gated to syntax errors only
+
+The qmllint gate matters: across the 53 files in frontend_v2 the linter reports
+~750 style diagnostics (unqualified access, missing-property) but zero [syntax]
+warnings and zero errors. Blocking on the style backlog would fire on untouched
+code, so only [syntax] and Error: lines fail the hook -- the same contract as
+compileall, which catches syntax and leaves style alone.
+
+Missing tooling is never fatal: a machine without a Qt kit (the Raspberry Pi
+deployment, a fresh clone) skips the QML check instead of blocking every edit.
+
+Exit codes:
+    0 -- nothing to check, tooling absent, or the check passed
+    2 -- the file is broken; stderr is fed back to the agent to fix
+'''
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+QMLLINT_ENV = "TESLA_HOMEDASH_QMLLINT"
+QT_GLOB = "*/msvc2022_64/bin/qmllint.exe"
+QT_ROOTS = ("D:/Qt", "C:/Qt")
+FATAL = re.compile(r"\[syntax\]|^Error:", re.MULTILINE)
+
+
+def version_key(path: Path) -> tuple:
+    '''
+    Builds a sort key from a Qt kit directory name so 6.11.1 beats 6.8.0.
+    Arguments:
+        path (Path): Path to a qmllint executable inside a Qt kit
+    '''
+    for part in path.parts:
+        if re.fullmatch(r"\d+(\.\d+)*", part):
+            return tuple(int(n) for n in part.split("."))
+    return (0,)
+
+
+def find_qmllint() -> str | None:
+    '''
+    Locates the newest installed qmllint, or None when no Qt kit is present.
+    An explicit TESLA_HOMEDASH_QMLLINT path always wins.
+    '''
+    override = os.environ.get(QMLLINT_ENV)
+    if override and Path(override).exists():
+        return override
+    found = []
+    for root in QT_ROOTS:
+        found.extend(Path(root).glob(QT_GLOB))
+    if not found:
+        return None
+    return str(max(found, key=version_key))
+
+
+def qml_import_root(qml_file: Path) -> Path | None:
+    '''
+    Walks up from a QML file to the module root, so generated modules resolve.
+    Without this the linter cannot import frontend_v2 and one unresolved import
+    cascades into hundreds of spurious unqualified-access warnings.
+    Arguments:
+        qml_file (Path): Absolute path to the edited .qml file
+    '''
+    for parent in qml_file.parents:
+        if (parent / "build").is_dir():
+            return parent / "build"
+    return None
+
+
+def check_backend(project_dir: str) -> tuple[int, str]:
+    '''
+    Byte-compiles the backend package to catch Python syntax errors.
+    Arguments:
+        project_dir (str): Repository root to run the compile from
+    '''
+    result = subprocess.run(
+        [sys.executable, "-m", "compileall", "-q", "backend/src"],
+        cwd=project_dir, capture_output=True, text=True,
+    )
+    return result.returncode, result.stdout + result.stderr
+
+
+def check_qml(qml_file: Path) -> tuple[int, str]:
+    '''
+    Lints one QML file, failing only on syntax errors.
+    Arguments:
+        qml_file (Path): Absolute path to the edited .qml file
+    '''
+    qmllint = find_qmllint()
+    if not qmllint:
+        return 0, ""
+    args = [qmllint]
+    import_root = qml_import_root(qml_file)
+    if import_root:
+        args += ["-I", str(import_root)]
+    args.append(str(qml_file))
+    result = subprocess.run(args, capture_output=True, text=True)
+    output = result.stdout + result.stderr
+    fatal = [line for line in output.splitlines() if FATAL.search(line)]
+    if fatal:
+        return 2, "\n".join(fatal)
+    return 0, ""
+
+
+def main() -> int:
+    '''
+    Reads the hook payload from stdin and runs the check matching the file type.
+    '''
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    raw_path = (payload.get("tool_input") or {}).get("file_path") or ""
+    if not raw_path:
+        return 0
+    file_path = Path(raw_path)
+    posix = file_path.as_posix()
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or payload.get("cwd") or "."
+
+    if posix.endswith(".py") and "backend/src" in posix:
+        code, output = check_backend(project_dir)
+    elif posix.endswith(".qml"):
+        code, output = check_qml(file_path)
+    else:
+        return 0
+
+    if code != 0:
+        sys.stderr.write(output)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,41 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python -m compileall:*)",
+      "Bash(uv run:*)",
+      "Bash(uv sync)",
+      "Bash(uv lock:*)",
+      "Bash(powershell -ExecutionPolicy Bypass -File scripts/build-frontend.ps1 *)",
+      "Bash(scripts/build-frontend.cmd *)",
+      "PowerShell(powershell -ExecutionPolicy Bypass -File scripts/build-frontend.ps1 *)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "Bash(git fetch:*)",
+      "Bash(git ls-remote:*)",
+      "Bash(git worktree list)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh repo view:*)",
+      "Bash(gh label list:*)"
+    ]
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PROJECT_DIR}/.claude/hooks/check-edit.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -677,12 +677,25 @@ Add inline comments only for non-obvious logic (protocol packing, formula eval, 
 transitions, scheduling edge cases). Don't comment self-explanatory code.
 
 ### 7.3 Agent validation policy
-The agent does **not** build or run the Qt frontend (no `cmake --build`, no launching `gui.exe`) —
-the user verifies frontend builds and runtime behaviour locally. Validate frontend changes by reading
-and reasoning about the code, and report what to look for at runtime. **Ignore clangd "file not found"
-/ "unknown type" diagnostics on Qt headers** in the editor — the real CMake build resolves them. Same
-for the backend: don't start long-running services; use `python -m compileall backend/src` for syntax
-checks and let the user run the live stack.
+**The agent builds the frontend** — compile errors should surface in the session that caused them, not
+on the user's next manual build. Use `scripts\build-frontend.ps1` (§8) after frontend changes; it is
+incremental and sccache-backed, so a rebuild after a small edit is cheap. Report build failures with
+the compiler output. Running the built binary is still the user's call (it needs the 1280×800 display
+and a live backend), so report what to look for at runtime rather than launching `gui.exe`.
+**Ignore clangd "file not found" / "unknown type" diagnostics on Qt headers** in the editor — the real
+CMake build resolves them. For the backend: don't start long-running services; `python -m compileall
+backend/src` is the syntax check and the user runs the live stack.
+
+**Automated pre-build checks.** `.claude/hooks/check-edit.py` runs on every agent Edit/Write and is the
+first line of defence, catching syntax breakage without a full build:
+- `backend/src/**.py` → `python -m compileall backend/src`
+- `**.qml` → `qmllint` (newest installed Qt kit; `TESLA_HOMEDASH_QMLLINT` overrides the path)
+
+The QML check is deliberately gated to `[syntax]` warnings and `Error:` lines. qmllint reports ~750
+style diagnostics across `frontend_v2` (mostly `unqualified` access and `missing-property`) but **zero**
+syntax warnings — blocking on that backlog would fire on untouched code, so the hook matches
+`compileall`'s contract: catch syntax, leave style alone. A machine with no Qt kit skips the QML check
+rather than blocking edits. The hook is a fast filter, not a substitute for the build.
 
 ### 7.4 Frontend logging
 - Format is byte-identical to the backend; stdout only, no files/rotation.
@@ -703,7 +716,7 @@ checks and let the user run the live stack.
   branch touches an issue only partially, reference it (`Refs #N`) without a closing keyword. Don't
   invent a link — only tie a PR to an issue the change genuinely resolves.
 - **Prompt to commit once work is verified.** This repo tends to accumulate uncommitted,
-  manually-verified changes (the frontend isn't agent-built, so verification happens on the user's
+  manually-verified changes (the agent builds, but *runtime* verification happens on the user's
   side). When the user confirms a feature works — i.e. they say a manual test passed — proactively
   prompt to commit it then, in focused commits per the above, rather than letting verified work pile
   up. The agent still only commits/pushes when the user agrees; this is about offering at the right
@@ -722,7 +735,17 @@ a new/renamed service or widget, a protocol change, a build-command change, or a
 invariant. Treat the doc as part of the change, not an afterthought, and bump §7.7.
 
 ### 7.7 Documentation currency
-This guide is current as of the **weather-service hang fix**: `WeatherService` had deadlocked on the
+This guide is current as of the **agent-builds-the-frontend policy change** (§7.3): the agent now runs
+`scripts\build-frontend.ps1` itself after frontend changes instead of deferring every build to the
+user, so compile errors surface in the session that caused them. Backing that up, `.claude/settings.json`
+(new, committed) registers a `PostToolUse` hook on `Edit|Write` running `.claude/hooks/check-edit.py`,
+which byte-compiles `backend/src` on Python edits and runs `qmllint` on QML edits — the latter gated to
+`[syntax]`/`Error:` only, because `frontend_v2` carries ~750 pre-existing style diagnostics but zero
+syntax warnings. `.claude/settings.local.json` was trimmed from 46 permission rules to 16 (project-wide
+rules moved into the committed `settings.json`; dead entries for removed MCP servers and a stale
+machine's statusline paths dropped). Note for future edits: `QT_QML_GENERATE_QMLLS_INI` is **deprecated
+since Qt 6.10** ("no replacement needed") — don't add it to `frontend_v2/CMakeLists.txt`.
+Predecessor work — the **weather-service hang fix**: `WeatherService` had deadlocked on the
 Pi for 16 days (widget empty, rest of the backend healthy). `fmiopendata`'s fetch helper calls
 `requests.get()` with no timeout, so a stalled FMI response parked an executor thread forever, and
 APScheduler's default `max_instances=1` then refused every later tick. Fixed in three layers, all
@@ -780,8 +803,8 @@ rebuild, `-Config Release`, `-Fullscreen`). From **cmd.exe** use the `.cmd` shim
 — works from the main checkout or any worktree. Open Qt Creator only when you need the debugger /
 QML profiler / designer. **sccache** is wired into `frontend_v2/CMakeLists.txt` (auto-enabled when
 on PATH), so object files are reused across rebuilds *and across worktrees* — a fresh worktree's
-"clean" build is mostly cache hits. Inspect with `sccache --show-stats`. (Per §7.3 the agent still
-doesn't build; it reasons about the code and the user runs the script.)
+"clean" build is mostly cache hits. Inspect with `sccache --show-stats`. (Per §7.3 the agent runs this
+script itself after frontend changes; the user still runs the built binary.)
 
 **When you *do* need a parallel session (worktree).**
 1. Ask the user **(a) what we're doing** and **(b) a short name**; choose the branch **type**


### PR DESCRIPTION
## Summary

Two changes that shorten the feedback loop on frontend work.

**1. A `PostToolUse` hook that checks edited files (`.claude/hooks/check-edit.py`).**
Dispatches by file type so each edit spawns one process:

| Edited file | Check |
|---|---|
| `backend/src/**.py` | `python -m compileall backend/src` (per CLAUDE.md §3.3) |
| `**.qml` | `qmllint` from the newest installed Qt kit |
| anything else | skipped |

**2. CLAUDE.md §7.3 — the agent now builds the frontend.**
Previously the agent never ran `cmake --build`, deferring every compile error to
the user's next manual build. Running the built binary stays with the user; it
needs the 1280×800 display and a live backend.

Also ships `.claude/settings.json` with the project-wide permission rules, so
they follow the repo into worktrees.

## Reason

Compile errors surfaced a session later than the change that caused them. The
build script is incremental and sccache-backed, so rebuilding after a small edit
is cheap — there was no real reason to defer it.

**Why the QML check ignores most of what qmllint says.** Raw qmllint across
`frontend_v2` emits 1824 lines. Passing `-I <build>` to resolve the generated
`frontend_v2` module cuts that to 751 — one unresolved import was cascading into
hundreds of spurious unqualified-access warnings. What remains is a pre-existing
style backlog (164 `unqualified`, 31 `missing-property`) that would fire on
untouched code. The 53 existing QML files contain **zero** `[syntax]` warnings
and **zero** errors, so gating the hook to `[syntax]`/`Error:` yields no false
positives today while still catching what breaks a build — the same contract
`compileall` has for Python.

A machine with no Qt kit skips the QML check rather than blocking every edit,
which matters because this settings file is committed and the Pi deployment has
no Qt kit. `TESLA_HOMEDASH_QMLLINT` overrides the discovered path.

## Manual verification

Hook, six cases:

| Case | Expected | Result |
|---|---|---|
| Clean QML (`Luna.qml`) | pass | exit 0 |
| QML with pre-existing style warnings (`ChargingLiveCard.qml`) | must **not** block | exit 0 |
| Broken QML (`width:` with no value) | block + diagnostic | exit 2, `Expected token ';' [syntax]` |
| Backend `.py` (`vehicle.py`) | compile | exit 0 |
| Unrelated file (`CMakeLists.txt`) | skip | exit 0 |
| No Qt kit installed | skip, not block | exit 0, no stderr |

Build policy: `scripts\build-frontend.ps1` run from the agent's environment —
**exit 0, 139/139 targets, `appfrontend_v2.exe` linked**.

No UI changes, so no screenshots.

## Notes

- `.claude/settings.local.json` stays gitignored; only shareable settings are committed.
- `QT_QML_GENERATE_QMLLS_INI` is **deprecated since Qt 6.10** ("no replacement
  needed") — recorded in §7.7 so it does not get added to
  `frontend_v2/CMakeLists.txt` in a future attempt to wire up qmlls.
- No open issues to link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GRvpuVkPhVRa3gFGKf8iRw
